### PR TITLE
add text reader

### DIFF
--- a/src/browser/client.ts
+++ b/src/browser/client.ts
@@ -1,5 +1,5 @@
 import { Client } from '../core/client';
-import { apiReader } from '../core/readers';
+import { apiReader, textReader } from '../core/readers';
 import {fileReader} from './readers';
 import { csv, tsv } from './parsers';
 import { json, ParserMethodsDefinition } from '../core/parsers';
@@ -11,6 +11,7 @@ import type {
 const readers: ReaderMethodsDefinition = {
   api: apiReader as ReaderDefinition,
   file: fileReader as ReaderDefinition,
+  text: textReader as ReaderDefinition
 };
 
 const parsers: ParserMethodsDefinition = {

--- a/src/core/readers.ts
+++ b/src/core/readers.ts
@@ -1,5 +1,9 @@
 type ReadAs = 'json' | 'text' | 'blob' | 'response';
 
+interface TextReaderParamsDefinition {
+  text: string
+}
+
 interface UrlReaderParamsDefinition {
   url: string;
   readAs: ReadAs;
@@ -19,6 +23,7 @@ export type ReaderDefinition = (
     | UrlReaderParamsDefinition
     | BlobReaderParamsDefinition
     | FileSystemReaderParamsDefinition
+    | TextReaderParamsDefinition
 ) => Promise<Blob | string | Response>;
 
 export interface ReaderMethodsDefinition {
@@ -41,6 +46,12 @@ export const apiReader = async ({
     return res.json();
   }
 };
+
+export const textReader = ({text}: TextReaderParamsDefinition) : Promise<string> => {
+  return new Promise((resolve, _) => {
+    resolve(text)
+  })
+}
 
 // export const s3 = (args: ReaderParamsDefinition) => {
 //   return args;

--- a/src/node/client.ts
+++ b/src/node/client.ts
@@ -1,5 +1,5 @@
 import { Client } from '../core/client';
-import { apiReader } from '../core/readers';
+import { apiReader, textReader } from '../core/readers';
 import { fileSystemReader } from './readers';
 import { csv, tsv } from './parsers';
 import { json } from '../core/parsers';
@@ -13,6 +13,7 @@ import { ParserMethodsDefinition } from '../core/parsers';
 const readers: ReaderMethodsDefinition = {
   api: apiReader as ReaderDefinition,
   file: fileSystemReader as ReaderDefinition,
+  text: textReader as ReaderDefinition
 };
 
 const parsers: ParserMethodsDefinition = {

--- a/src/node/readers.ts
+++ b/src/node/readers.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'fs/promises';
-import { FileSystemReaderParamsDefinition } from '../core/readers';
+import { FileSystemReaderParamsDefinition,  } from '../core/readers';
 
 export const fileSystemReader = async ({
   path,


### PR DESCRIPTION
Adds a simple text reader, allows users to pass data as a string when file, api etc. reading isnt required and still comply with the `reader` interface 