### PR TITLE
Added the ability to use non-value fields for flags

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -40,6 +40,7 @@ import { Sensor, Sensors } from "./sensor";
 import {
 	cleanKey,
 	formatValueForLog,
+	getArray,
 	getBoolean,
 	getNumber,
 	getString,
@@ -73,6 +74,7 @@ export abstract class Client<
 	// if longFormat = false this value is ignored
 	parameterNameKey: string | PathExpression | ParseFunction = "parameter";
 	parameterValueKey: string | PathExpression | ParseFunction = "value";
+	flagsKey: string | PathExpression | ParseFunction = "flags";
 	yGeometryKey: string | PathExpression | ParseFunction = "y";
 	xGeometryKey: string | PathExpression | ParseFunction = "x";
 	manufacturerKey: string | PathExpression | ParseFunction =
@@ -160,6 +162,9 @@ export abstract class Client<
 		}
 		if (this.#params?.parameterValueKey) {
 			this.parameterValueKey = this.#params.parameterValueKey;
+		}
+		if (this.#params?.flagsKey) {
+			this.flagsKey = this.#params.flagsKey;
 		}
 		if (this.#params?.yGeometryKey) {
 			this.yGeometryKey = this.#params.yGeometryKey;
@@ -628,6 +633,10 @@ export abstract class Client<
 					const valueName = this.longFormat ? this.parameterValueKey : p;
 
 					const value = getValueFromKey(measurementRow, valueName);
+					// flags must be an array so we need to check that somewhere
+					const flags = getArray(measurementRow, this.flagsKey)?.map(
+						(f) => `${this.provider}::${f}`,
+					);
 
 					// for wide format data we will not assume that null is a real measurement
 					// but for long format data we will assume it is valid
@@ -662,6 +671,7 @@ export abstract class Client<
 								sensor: sensor,
 								timestamp: datetime,
 								value: value,
+								flags: flags,
 							}),
 						);
 					}

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -167,6 +167,7 @@ export abstract class Client<
 		}
 		if (this.#params?.flagsKey) {
 			this.flagsKey = this.#params.flagsKey;
+		}
 		if (this.#params?.numberFormat) {
 			this.numberFormat = this.#params.numberFormat;
 		}

--- a/src/core/measurement.ts
+++ b/src/core/measurement.ts
@@ -107,6 +107,9 @@ export class Measurement {
 		this.value = null;
 		this.sensor = data.sensor;
 		this.timestamp = data.timestamp;
+		if (data.flags && data.flags?.length) {
+			this.flags = [...data.flags];
+		}
 		// the csv parser does not convert values to numbers
 		// should we do something here to do that?
 		// the only issue I see is if we expect a flag here, in which case we could catch an error?
@@ -119,7 +122,10 @@ export class Measurement {
 		} catch (e: unknown) {
 			if (e instanceof TransformError) {
 				if (e?.flag) {
-					this.flags = [String(e.flag)];
+					if (!this.flags) {
+						this.flags = [];
+					}
+					this.flags.push(String(e.flag));
 				}
 				this.value = typeof e.value === "number" ? e.value : null;
 			}

--- a/src/core/measurement.ts
+++ b/src/core/measurement.ts
@@ -110,7 +110,7 @@ export class Measurement {
 		this.value = null;
 		this.sensor = data.sensor;
 		this.timestamp = data.timestamp;
-		if (data.flags && data.flags?.length) {
+		if (data.flags?.length) {
 			this.flags = [...data.flags];
 		}
 		// the csv parser does not convert values to numbers

--- a/src/core/utils.spec.ts
+++ b/src/core/utils.spec.ts
@@ -227,7 +227,7 @@ describe('getBoolean', () => {
   });
 });
 
-describe.only('getArray tests', () => {
+describe('getArray tests', () => {
   test('returns array for string array', () => {
     expect(getArray(record(['some-value']), key)).toStrictEqual(['some-value']);
   });

--- a/src/core/utils.spec.ts
+++ b/src/core/utils.spec.ts
@@ -8,6 +8,7 @@ import {
   getBoolean,
   getNumber,
   getString,
+  getArray,
   getValueFromKey,
 } from './utils.ts';
 
@@ -224,4 +225,29 @@ describe('getBoolean', () => {
   test('returns true for a non-empty arbitrary string', () => {
     expect(getBoolean(record('some-value'), key)).toBe(true);
   });
+});
+
+describe.only('getArray tests', () => {
+  test('returns array for string array', () => {
+    expect(getArray(record(['some-value']), key)).toStrictEqual(['some-value']);
+  });
+  test('returns array for string', () => {
+    expect(getArray(record('some-value'), key)).toStrictEqual(['some-value']);
+  });
+  test('returns array for numeric array', () => {
+    expect(getArray(record([0]), key)).toStrictEqual([0]);
+  });
+  test('returns array for number', () => {
+    expect(getArray(record(0), key)).toStrictEqual([0]);
+  });
+  test('returns undefined for undefined', () => {
+    expect(getArray(record(undefined), key)).toBeUndefined();
+  });
+  test('returns undefined for null', () => {
+    expect(getArray(record(null), key)).toBeUndefined();
+  });
+  test('returns empty array for array', () => {
+    expect(getArray(record([]), key)).toStrictEqual([]);
+  });
+
 });

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -131,3 +131,18 @@ export const getBoolean = (
 	}
 	return Boolean(value);
 };
+
+export const getArray = (
+	data: SourceRecord,
+	key: ParseFunction | string | PathExpression,
+): (string | number)[] | undefined => {
+	const value = getValueFromKey(data, key) as
+		| number
+		| null
+		| string
+		| number[]
+		| string[];
+	if (value == null || value === "") return undefined;
+	if (!Array.isArray(value)) return [value];
+	return value;
+};

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -133,6 +133,7 @@ export interface ClientConfiguration {
 	locationLabelKey?: string | ParseFunction;
 	parameterNameKey?: string | ParseFunction;
 	parameterValueKey?: string | ParseFunction;
+	flagsKey?: string | ParseFunction;
 	xGeometryKey?: string | ParseFunction;
 	yGeometryKey?: string | ParseFunction;
 	geometryProjectionKey?: string | ParseFunction;


### PR DESCRIPTION
  Based on the way that clarity currently does it.

The goal here is that something like this (as a measurement)
```
{
            "datasourceId": "DCQYT1459"
            "time": "2023-11-03T19:00:00.000Z",
            "status": "calibrated-ready",
            "value": 8192.31,
            "raw": 3019.89,
            "metric": "pm2_5ConcMass1HourMean",
            "qcAssessment": "invalid",
            "qcFlags": ["QC.I.OOB.001", "QC.I.OOB.002"]
        },
```
Is transformed to this
```
    {
      "key": "clarity-DTZZ1111-pm25:mass",
      "timestamp": "2025-09-11T12:38:11.937Z",
      "value": 8192,
      "flags": ["clarity::QC.I.OOB.001", "clarity::QC.I.OOB.002"]
    },
```
The names, e.g. `clarity::QC.I.OOB.001, will then be matched to flag_types in our db via the ingestor. And a flag_type includes a flag level. Based on this process we will have to set the flag levels manually for each type. But I think that is a safer solution then trying to build the flags via ingestion as well. But I am open to other opinions of course. 
