### PR TITLE
Adding datetime to and from to client

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -224,7 +224,7 @@ export abstract class Client<
 				this.#datetimeFrom = new Datetime(this.#params.datetimeFrom);
 			} catch (e) {
 				throw new Error(
-					`Config error: could not parse datetimeFrom value - ${e.message}`,
+					`Config error: could not parse datetimeFrom value - ${e instanceof Error ? e.message : String(e)}`,
 				);
 			}
 		}
@@ -233,7 +233,7 @@ export abstract class Client<
 				this.#datetimeTo = new Datetime(this.#params.datetimeTo);
 			} catch (e) {
 				throw new Error(
-					`Config error: could not parse datetimeTo value - ${e.message}`,
+					`Config error: could not parse datetimeTo value - ${e instanceof Error ? e.message : String(e)}`,
 				);
 			}
 		}

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -109,12 +109,11 @@ export abstract class Client<
 	#sensors: Sensors;
 	#errors: Errors;
 	#params: ClientConfiguration;
-  // offset, to, from support
-  // limit the returned values to the following periods
-  #datetimeFrom?: Datetime;
-  #datetimeTo?: Datetime;
-  #offset?: number;
-
+	// offset, to, from support
+	// limit the returned values to the following periods
+	#datetimeTo: Datetime;
+	#datetimeFrom?: Datetime;
+	#offset?: number;
 
 	// log object for compiling errors/warnings for later reference
 	log: Map<string, Array<LogEntry>>;
@@ -221,37 +220,43 @@ export abstract class Client<
 			this.secrets = this.#params.secrets;
 		}
 		if (this.#params?.datetimeFrom) {
-      try {
-        this.#datetimeFrom = new Datetime(this.#params.datetimeFrom);
-      } catch (e) {
-        throw new Error(`Config error: could not parse datetimeFrom value - ${this.#params.datetimeFrom}`);
-      }
+			try {
+				this.#datetimeFrom = new Datetime(this.#params.datetimeFrom);
+			} catch (e) {
+				throw new Error(
+					`Config error: could not parse datetimeFrom value - ${e.message}`,
+				);
+			}
 		}
 		if (this.#params?.datetimeTo) {
-      try {
-        this.#datetimeTo = new Datetime(this.#params.datetimeTo);
-      } catch (e) {
-        throw new Error(`Config error: could not parse datetimeTo value - ${this.#params.datetimeTo}`);
-      }
+			try {
+				this.#datetimeTo = new Datetime(this.#params.datetimeTo);
+			} catch (e) {
+				throw new Error(
+					`Config error: could not parse datetimeTo value - ${e.message}`,
+				);
+			}
 		}
-    if (this.#params?.offset !== undefined) {
-      if (typeof this.#params.offset !== 'number' || this.#params.offset <= 0) {
-        throw new Error(`Config error: offset must be a positive number, got ${this.#params.offset}`);
-      }
-      this.#offset = this.#params.offset;
-    }
+		if (this.#params?.offset !== undefined) {
+			if (typeof this.#params.offset !== "number" || this.#params.offset <= 0) {
+				throw new Error(
+					`Config error: offset must be a positive number, got ${this.#params.offset}`,
+				);
+			}
+			this.#offset = this.#params.offset;
+		}
 
-    // if there is no datetimeTo we default to now
-    // minus any buffer to deal with hourly data that might be time begining
-    if (!this.#datetimeTo) {
-      this.#datetimeTo = Datetime.now();
-    }
+		// if there is no datetimeTo we default to now
+		// minus any buffer to deal with hourly data that might be time begining
+		if (!this.#datetimeTo) {
+			this.#datetimeTo = Datetime.now();
+		}
 
-    // if there is no datetimeFrom but we have an offset
-    // we default to using datetimeTo - offset
-    if (!this.#datetimeFrom && this.#offset) {
-      this.#datetimeFrom = this.#datetimeTo.minus(this.#offset);
-    }
+		// if there is no datetimeFrom but we have an offset
+		// we default to using datetimeTo - offset
+		if (!this.#datetimeFrom && this.#offset) {
+			this.#datetimeFrom = this.#datetimeTo.minus(this.#offset);
+		}
 
 		this.#locations = new Locations();
 		this.#sensors = new Sensors();
@@ -760,12 +765,12 @@ export abstract class Client<
 			try {
 				const datetime = this.getDatetime(measurementRow);
 
-        if (
-          datetime.isGreaterThan(this.#datetimeTo)
-            || (this.#datetimeFrom && datetime.isLessThan(this.#datetimeFrom))
-        ) {
-          return;
-        }
+				if (
+					datetime.isGreaterThan(this.#datetimeTo) ||
+					(this.#datetimeFrom && datetime.isLessThan(this.#datetimeFrom))
+				) {
+					return;
+				}
 
 				params.forEach((p) => {
 					// for long format data we will need to extract the parameter name from the field

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -93,12 +93,6 @@ export abstract class Client<
 	datasources: object = {};
 	missingDatasources: string[] = [];
 
-  // offset, to, from support
-  // limit the returned values to the following periods
-  datetimeFrom?: string;
-  datetimeTo?: string;
-  offset?: number;
-
 	// this should be the list of parameters in the data and how to extract them
 	// transforming could be later
 	parameters: ClientParameters = PARAMETER_DEFAULTS;
@@ -115,6 +109,12 @@ export abstract class Client<
 	#sensors: Sensors;
 	#errors: Errors;
 	#params: ClientConfiguration;
+  // offset, to, from support
+  // limit the returned values to the following periods
+  #datetimeFrom?: Datetime;
+  #datetimeTo?: Datetime;
+  #offset?: number;
+
 
 	// log object for compiling errors/warnings for later reference
 	log: Map<string, Array<LogEntry>>;
@@ -221,31 +221,36 @@ export abstract class Client<
 			this.secrets = this.#params.secrets;
 		}
 		if (this.#params?.datetimeFrom) {
-			this.datetimeFrom = new Datetime(this.#params.datetimeFrom);
-      if(!this.datetimeFrom) throw new Error(`Config error: could not parse datetimeFrom value - ${this.#params?.datetimeFrom}`)
+      try {
+        this.#datetimeFrom = new Datetime(this.#params.datetimeFrom);
+      } catch (e) {
+        throw new Error(`Config error: could not parse datetimeFrom value - ${this.#params.datetimeFrom}`);
+      }
 		}
 		if (this.#params?.datetimeTo) {
-			this.datetimeTo = new Datetime(this.#params.datetimeTo);
-      if(!this.datetimeTo) throw new Error(`Config error: could not parse datetimeTo value - ${this.#params?.datetimeTo}`)
+      try {
+        this.#datetimeTo = new Datetime(this.#params.datetimeTo);
+      } catch (e) {
+        throw new Error(`Config error: could not parse datetimeTo value - ${this.#params.datetimeTo}`);
+      }
 		}
-		if (this.#params?.offset) {
-			this.offset = this.#params.offset;
-      // check if its a number
-		}
-
-    // if there is no offset we default to 3 hours
-    if (!this.offset) {
-      this.offset = 3 * 3600;
+    if (this.#params?.offset !== undefined) {
+      if (typeof this.#params.offset !== 'number' || this.#params.offset <= 0) {
+        throw new Error(`Config error: offset must be a positive number, got ${this.#params.offset}`);
+      }
+      this.#offset = this.#params.offset;
     }
+
     // if there is no datetimeTo we default to now
     // minus any buffer to deal with hourly data that might be time begining
-    if (!this.datetimeTo) {
-      this.datetimeTo = Datetime.now();
+    if (!this.#datetimeTo) {
+      this.#datetimeTo = Datetime.now();
     }
 
-    // if there is no datetimeFrom we default to using datetimeTo - offset
-    if (!this.datetimeFrom) {
-      this.datetimeFrom = this.datetimeTo.minus(this.offset);
+    // if there is no datetimeFrom but we have an offset
+    // we default to using datetimeTo - offset
+    if (!this.#datetimeFrom && this.#offset) {
+      this.#datetimeFrom = this.#datetimeTo.minus(this.#offset);
     }
 
 		this.#locations = new Locations();
@@ -755,7 +760,10 @@ export abstract class Client<
 			try {
 				const datetime = this.getDatetime(measurementRow);
 
-        if (datetime.isLessThan(this.datetimeFrom) || datetime.isGreaterThan(this.datetimeTo)) {
+        if (
+          datetime.isGreaterThan(this.#datetimeTo)
+            || (this.#datetimeFrom && datetime.isLessThan(this.#datetimeFrom))
+        ) {
           return;
         }
 

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -93,7 +93,11 @@ export abstract class Client<
 	datasources: object = {};
 	missingDatasources: string[] = [];
 
-	// TODO _secrets = {}
+  // offset, to, from support
+  // limit the returned values to the following periods
+  datetimeFrom?: string;
+  datetimeTo?: string;
+  offset?: number;
 
 	// this should be the list of parameters in the data and how to extract them
 	// transforming could be later
@@ -216,6 +220,33 @@ export abstract class Client<
 		if (this.#params?.secrets) {
 			this.secrets = this.#params.secrets;
 		}
+		if (this.#params?.datetimeFrom) {
+			this.datetimeFrom = new Datetime(this.#params.datetimeFrom);
+      if(!this.datetimeFrom) throw new Error(`Config error: could not parse datetimeFrom value - ${this.#params?.datetimeFrom}`)
+		}
+		if (this.#params?.datetimeTo) {
+			this.datetimeTo = new Datetime(this.#params.datetimeTo);
+      if(!this.datetimeTo) throw new Error(`Config error: could not parse datetimeTo value - ${this.#params?.datetimeTo}`)
+		}
+		if (this.#params?.offset) {
+			this.offset = this.#params.offset;
+      // check if its a number
+		}
+
+    // if there is no offset we default to 3 hours
+    if (!this.offset) {
+      this.offset = 3 * 3600;
+    }
+    // if there is no datetimeTo we default to now
+    // minus any buffer to deal with hourly data that might be time begining
+    if (!this.datetimeTo) {
+      this.datetimeTo = Datetime.now();
+    }
+
+    // if there is no datetimeFrom we default to using datetimeTo - offset
+    if (!this.datetimeFrom) {
+      this.datetimeFrom = this.datetimeTo.minus(this.offset);
+    }
 
 		this.#locations = new Locations();
 		this.#sensors = new Sensors();
@@ -723,6 +754,10 @@ export abstract class Client<
 		measurements.forEach((measurementRow: SourceRecord) => {
 			try {
 				const datetime = this.getDatetime(measurementRow);
+
+        if (datetime.isLessThan(this.datetimeFrom) || datetime.isGreaterThan(this.datetimeTo)) {
+          return;
+        }
 
 				params.forEach((p) => {
 					// for long format data we will need to extract the parameter name from the field

--- a/src/core/datetime.spec.ts
+++ b/src/core/datetime.spec.ts
@@ -227,3 +227,60 @@ test("toString with format string returns formatted date", () => {
     const datetime = new Datetime("2025-01-01T00:00:00-05:00");
     expect(datetime.toString("yyyy-MM-dd")).toBe("2025-01-01");
 });
+
+test("minus returns a new Datetime instance", () => {
+	const datetime = new Datetime("2025-01-01T12:00:00Z");
+	const result = datetime.minus(60);
+	expect(result).toBeInstanceOf(Datetime);
+	expect(result).not.toBe(datetime);
+});
+
+test("minus does not mutate original instance", () => {
+	const datetime = new Datetime("2025-01-01T12:00:00Z");
+	datetime.minus(3600);
+	expect(datetime.toUTC()).toBe("2025-01-01T12:00:00Z");
+});
+
+test("minus with string throws luxon error", () => {
+	const datetime = new Datetime("2025-01-01T12:00:00Z");
+	expect(() => datetime.minus('60')).toThrow();
+});
+
+test("object with misnamed key throws luxon error", () => {
+	const datetime = new Datetime("2025-01-01T12:00:00Z");
+	expect(() => datetime.minus({ h: 2 })).toThrow();
+});
+
+test("minus with negative number throws RangeError", () => {
+	const datetime = new Datetime("2025-01-01T12:00:00Z");
+	expect(() => datetime.minus(-60)).toThrow(RangeError);
+});
+
+test("object with negative number throws RangeError", () => {
+	const datetime = new Datetime("2025-01-01T12:00:00Z");
+	expect(() => datetime.minus({ hours: -1 })).toThrow(RangeError);
+});
+
+test("Duration with negative number throws RangeError", () => {
+	const datetime = new Datetime("2025-01-01T12:00:00Z");
+	expect(() => datetime.minus(Duration.fromObject({ hours: -1 }))).toThrow(RangeError);
+});
+
+test("minus preserves locationTimezone", () => {
+	const datetime = new Datetime("2025-01-01 12:00", {
+		format: "yyyy-MM-dd HH:mm",
+		timezone: "America/Denver",
+		locationTimezone: "America/Denver",
+	});
+	const result = datetime.minus(3600);
+	expect(result.toLocal()).toBe("2025-01-01T11:00:00-07:00");
+});
+
+test("minus with all three input types produces the same result", () => {
+	const datetime = new Datetime("2025-01-01T12:00:00Z");
+	const fromNumber = datetime.minus(3600);
+	const fromDuration = datetime.minus(Duration.fromObject({ hours: 1 }));
+	const fromOffset = datetime.minus({ hours: 1 });
+	expect(fromNumber.toUTC()).toBe(fromDuration.toUTC());
+	expect(fromDuration.toUTC()).toBe(fromOffset.toUTC());
+});

--- a/src/core/datetime.ts
+++ b/src/core/datetime.ts
@@ -232,23 +232,24 @@ export class Datetime {
 		let dt: DateTime;
 
 		if (typeof timeOffset === "number") {
-      if (timeOffset < 0) {
-        throw new RangeError("timeOffset must be a positive number");
-      }
+			if (timeOffset < 0) {
+				throw new RangeError("timeOffset must be a positive number");
+			}
 			dt = this.date.minus(timeOffset * 1000);
 		} else {
-      if (!(timeOffset instanceof Duration)) {
-        timeOffset = Duration.fromObject(timeOffset)
-      }
-      if (timeOffset.as('seconds') < 0 ) {
-        throw new RangeError("timeOffset must be a positive number");
-      }
-			dt = this.date.minus(timeOffset);
+			const dur =
+				timeOffset instanceof Duration
+					? timeOffset
+					: Duration.fromObject(timeOffset);
+			if (dur.as("seconds") < 0) {
+				throw new RangeError("timeOffset must be a positive number");
+			}
+			dt = this.date.minus(dur);
 		}
 
 		return new Datetime(dt, {
-      locationTimezone: this.locationTimezone,
-    });
+			locationTimezone: this.locationTimezone,
+		});
 	}
 
 	/**

--- a/src/core/datetime.ts
+++ b/src/core/datetime.ts
@@ -264,6 +264,4 @@ export class Datetime {
 
 		return new Datetime(dt);
 	}
-
-
 }

--- a/src/core/datetime.ts
+++ b/src/core/datetime.ts
@@ -221,6 +221,28 @@ export class Datetime {
 	}
 
 	/**
+	 * Creates a new Datetime instance representing the internal date/time,
+	 * minus the required offset value.
+	 *
+	 * @param {number | Duration | TimeOffset} [timeOffset=0] - The amount to subtract from the current time.
+	 *
+	 * @returns {Datetime} A new Datetime instance adjusted by the specified offset
+	 */
+	minus(timeOffset: number | Duration | TimeOffset): Datetime {
+		let dt: DateTime;
+
+		if (typeof timeOffset === "number") {
+			dt = this.date.minus(Math.abs(timeOffset) * 1000);
+		} else if (timeOffset instanceof Duration) {
+			dt = this.date.minus(timeOffset);
+		} else {
+			dt = this.date.minus(timeOffset);
+		}
+
+		return new Datetime(dt);
+	}
+
+	/**
 	 * Creates a new Datetime instance representing the current date and time,
 	 * optionally adjusted by a specified offset into the past.
 	 *
@@ -242,4 +264,6 @@ export class Datetime {
 
 		return new Datetime(dt);
 	}
+
+
 }

--- a/src/core/datetime.ts
+++ b/src/core/datetime.ts
@@ -232,14 +232,23 @@ export class Datetime {
 		let dt: DateTime;
 
 		if (typeof timeOffset === "number") {
-			dt = this.date.minus(Math.abs(timeOffset) * 1000);
-		} else if (timeOffset instanceof Duration) {
-			dt = this.date.minus(timeOffset);
+      if (timeOffset < 0) {
+        throw new RangeError("timeOffset must be a positive number");
+      }
+			dt = this.date.minus(timeOffset * 1000);
 		} else {
+      if (!(timeOffset instanceof Duration)) {
+        timeOffset = Duration.fromObject(timeOffset)
+      }
+      if (timeOffset.as('seconds') < 0 ) {
+        throw new RangeError("timeOffset must be a positive number");
+      }
 			dt = this.date.minus(timeOffset);
 		}
 
-		return new Datetime(dt);
+		return new Datetime(dt, {
+      locationTimezone: this.locationTimezone,
+    });
 	}
 
 	/**

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -153,10 +153,9 @@ export interface ClientConfiguration {
 	parameters?: ClientParameters;
 	ingestMatchingMethod?: IngestMatchingMethod;
 
-  datetimeFrom?: string;
-  datetimeTo?: string;
-  offset?: number;
-
+	datetimeFrom?: string;
+	datetimeTo?: string;
+	offset?: number;
 }
 
 export type IndexedReader<T> = Partial<Record<ResourceKeys, keyof T | Reader>>;

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -152,6 +152,11 @@ export interface ClientConfiguration {
 	missingDatasources?: string[];
 	parameters?: ClientParameters;
 	ingestMatchingMethod?: IngestMatchingMethod;
+
+  datetimeFrom?: string;
+  datetimeTo?: string;
+  offset?: number;
+
 }
 
 export type IndexedReader<T> = Partial<Record<ResourceKeys, keyof T | Reader>>;


### PR DESCRIPTION
This is to deal with adapters that return a lot of data and we want to limit it by filtering out things that we likely already have. 

This is just a draft so I am interested in feedback. We are trying to support a few different things

- We want to limit data for fetchers that are run every hour or so
- But we want to be able to also pull in all the data that we can, for example, when first starting a provider
- And we want to be able to fetch archived data, if possible. 

The following proposal will limit data but there is no way to get it to allow all data the way I have it set up. So we need a way to tell it to not filter by dates. 

Or maybe we just leave it like this and pass a large range when we want to capture everything?