### PR TITLE
add timeEnding option to client

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -70,6 +70,7 @@ export abstract class Client<
 	longFormat: boolean = false;
 	geometryProjectionKey: string | PathExpression | ParseFunction = "projection";
 	datetimeFormat: string = "yyyy-MM-dd'T'HH:mm:ssZZ";
+	timeEnding: boolean = true;
 
 	// mapped data variables
 	locationIdKey: string | PathExpression | ParseFunction = "location";
@@ -200,6 +201,9 @@ export abstract class Client<
 		}
 		if (this.#params?.datetimeKey) {
 			this.datetimeKey = this.#params.datetimeKey;
+		}
+		if (this.#params?.timeEnding !== undefined) {
+			this.timeEnding = this.#params.timeEnding;
 		}
 		if (this.#params?.licenseKey) {
 			this.licenseKey = this.#params.licenseKey;
@@ -415,7 +419,7 @@ export abstract class Client<
 	 * @param {*} row - data with fields to create timestamp
 	 * @returns {string} - formated timestamp string
 	 */
-	getDatetime(row: SourceRecord): Datetime {
+	getDatetime(row: SourceRecord, timeEnding: boolean, averagingIntervalSeconds: number | undefined): Datetime {
 		const dtString = getValueFromKey(row, this.datetimeKey);
 		log(`getDatetime`, dtString);
 		if (typeof dtString !== "string" || !dtString) {
@@ -423,11 +427,16 @@ export abstract class Client<
 				`Missing date/time field. Looking in ${formatValueForLog(this.datetimeKey)}`,
 			);
 		}
-
-		const dt = new Datetime(dtString, {
+		let dt = new Datetime(dtString, {
 			format: this.datetimeFormat,
 			timezone: this.timezone,
 		});
+		if (!timeEnding) {
+			if (!averagingIntervalSeconds) {
+				throw new Error("averagingIntervalSeconds required when timeEnding is false");
+			}
+			dt = dt.add(averagingIntervalSeconds);
+		}
 		return dt;
 	}
 
@@ -596,8 +605,6 @@ export abstract class Client<
 
 	/**
 	 * Entry point for processing data
-	 *
-	 * @param {(string|file|object)} file - file path, object or file
 	 */
 	async load() {
 		log(`Starting the load process`);
@@ -796,15 +803,6 @@ export abstract class Client<
 
 		measurements.forEach((measurementRow: SourceRecord) => {
 			try {
-				const datetime = this.getDatetime(measurementRow);
-
-				if (
-					datetime.isGreaterThan(this.#datetimeTo) ||
-					(this.#datetimeFrom && datetime.isLessThan(this.#datetimeFrom))
-				) {
-					return;
-				}
-
 				params.forEach((p) => {
 					// for long format data we will need to extract the parameter name from the field
 					// for wide format they are both the same value
@@ -850,6 +848,14 @@ export abstract class Client<
 									metric,
 								}),
 							);
+							return;
+						}
+						const averagingIntervalSeconds = sensor.averagingIntervalSeconds;
+						const datetime = this.getDatetime(measurementRow, this.timeEnding, averagingIntervalSeconds);
+						if (
+							datetime.isGreaterThan(this.#datetimeTo) ||
+							(this.#datetimeFrom && datetime.isLessThan(this.#datetimeFrom))
+						) {
 							return;
 						}
 						this.measurements.add(

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -419,7 +419,11 @@ export abstract class Client<
 	 * @param {*} row - data with fields to create timestamp
 	 * @returns {string} - formated timestamp string
 	 */
-	getDatetime(row: SourceRecord, timeEnding: boolean, averagingIntervalSeconds: number | undefined): Datetime {
+	getDatetime(
+		row: SourceRecord,
+		timeEnding: boolean,
+		averagingIntervalSeconds: number | undefined,
+	): Datetime {
 		const dtString = getValueFromKey(row, this.datetimeKey);
 		log(`getDatetime`, dtString);
 		if (typeof dtString !== "string" || !dtString) {
@@ -433,7 +437,9 @@ export abstract class Client<
 		});
 		if (!timeEnding) {
 			if (!averagingIntervalSeconds) {
-				throw new Error("averagingIntervalSeconds required when timeEnding is false");
+				throw new Error(
+					"averagingIntervalSeconds required when timeEnding is false",
+				);
 			}
 			dt = dt.add(averagingIntervalSeconds);
 		}
@@ -851,7 +857,11 @@ export abstract class Client<
 							return;
 						}
 						const averagingIntervalSeconds = sensor.averagingIntervalSeconds;
-						const datetime = this.getDatetime(measurementRow, this.timeEnding, averagingIntervalSeconds);
+						const datetime = this.getDatetime(
+							measurementRow,
+							this.timeEnding,
+							averagingIntervalSeconds,
+						);
 						if (
 							datetime.isGreaterThan(this.#datetimeTo) ||
 							(this.#datetimeFrom && datetime.isLessThan(this.#datetimeFrom))

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -421,7 +421,6 @@ export abstract class Client<
 	 */
 	getDatetime(
 		row: SourceRecord,
-		timeEnding: boolean,
 		averagingIntervalSeconds: number | undefined,
 	): Datetime {
 		const dtString = getValueFromKey(row, this.datetimeKey);
@@ -435,7 +434,7 @@ export abstract class Client<
 			format: this.datetimeFormat,
 			timezone: this.timezone,
 		});
-		if (!timeEnding) {
+		if (!this.timeEnding) {
 			if (!averagingIntervalSeconds) {
 				throw new Error(
 					"averagingIntervalSeconds required when timeEnding is false",
@@ -859,7 +858,6 @@ export abstract class Client<
 						const averagingIntervalSeconds = sensor.averagingIntervalSeconds;
 						const datetime = this.getDatetime(
 							measurementRow,
-							this.timeEnding,
 							averagingIntervalSeconds,
 						);
 						if (

--- a/src/core/datetime.spec.ts
+++ b/src/core/datetime.spec.ts
@@ -246,7 +246,7 @@ test("minus with string throws luxon error", () => {
 	expect(() => datetime.minus('60')).toThrow();
 });
 
-test("object with misnamed key throws luxon error", () => {
+test("minus with object with misnamed key throws luxon error", () => {
 	const datetime = new Datetime("2025-01-01T12:00:00Z");
 	expect(() => datetime.minus({ h: 2 })).toThrow();
 });
@@ -256,12 +256,12 @@ test("minus with negative number throws RangeError", () => {
 	expect(() => datetime.minus(-60)).toThrow(RangeError);
 });
 
-test("object with negative number throws RangeError", () => {
+test("minus with object with negative number throws RangeError", () => {
 	const datetime = new Datetime("2025-01-01T12:00:00Z");
 	expect(() => datetime.minus({ hours: -1 })).toThrow(RangeError);
 });
 
-test("Duration with negative number throws RangeError", () => {
+test("minus with Duration with negative number throws RangeError", () => {
 	const datetime = new Datetime("2025-01-01T12:00:00Z");
 	expect(() => datetime.minus(Duration.fromObject({ hours: -1 }))).toThrow(RangeError);
 });
@@ -281,6 +281,65 @@ test("minus with all three input types produces the same result", () => {
 	const fromNumber = datetime.minus(3600);
 	const fromDuration = datetime.minus(Duration.fromObject({ hours: 1 }));
 	const fromOffset = datetime.minus({ hours: 1 });
+	expect(fromNumber.toUTC()).toBe(fromDuration.toUTC());
+	expect(fromDuration.toUTC()).toBe(fromOffset.toUTC());
+});
+
+
+
+test("add returns a new Datetime instance", () => {
+	const datetime = new Datetime("2025-01-01T12:00:00Z");
+	const result = datetime.add(60);
+	expect(result).toBeInstanceOf(Datetime);
+	expect(result).not.toBe(datetime);
+});
+
+test("add does not mutate original instance", () => {
+	const datetime = new Datetime("2025-01-01T12:00:00Z");
+	datetime.add(3600);
+	expect(datetime.toUTC()).toBe("2025-01-01T12:00:00Z");
+});
+
+test("add with string throws luxon error", () => {
+	const datetime = new Datetime("2025-01-01T12:00:00Z");
+	expect(() => datetime.add('60')).toThrow();
+});
+
+test("add with object with misnamed key throws luxon error with add", () => {
+	const datetime = new Datetime("2025-01-01T12:00:00Z");
+	expect(() => datetime.add({ h: 2 })).toThrow();
+});
+
+test("add with negative number throws RangeError", () => {
+	const datetime = new Datetime("2025-01-01T12:00:00Z");
+	expect(() => datetime.add(-60)).toThrow(RangeError);
+});
+
+test("add with object with negative number throws RangeError", () => {
+	const datetime = new Datetime("2025-01-01T12:00:00Z");
+	expect(() => datetime.add({ hours: -1 })).toThrow(RangeError);
+});
+
+test("add with Duration with negative number throws RangeError", () => {
+	const datetime = new Datetime("2025-01-01T12:00:00Z");
+	expect(() => datetime.add(Duration.fromObject({ hours: -1 }))).toThrow(RangeError);
+});
+
+test("add preserves locationTimezone", () => {
+	const datetime = new Datetime("2025-01-01 12:00", {
+		format: "yyyy-MM-dd HH:mm",
+		timezone: "America/Denver",
+		locationTimezone: "America/Denver",
+	});
+	const result = datetime.add(3600);
+	expect(result.toLocal()).toBe("2025-01-01T13:00:00-07:00");
+});
+
+test("add with all three input types produces the same result", () => {
+	const datetime = new Datetime("2025-01-01T12:00:00Z");
+	const fromNumber = datetime.add(3600);
+	const fromDuration = datetime.add(Duration.fromObject({ hours: 1 }));
+	const fromOffset = datetime.add({ hours: 1 });
 	expect(fromNumber.toUTC()).toBe(fromDuration.toUTC());
 	expect(fromDuration.toUTC()).toBe(fromOffset.toUTC());
 });

--- a/src/core/datetime.ts
+++ b/src/core/datetime.ts
@@ -220,6 +220,39 @@ export class Datetime {
 		return this.toLocal(formatString);
 	}
 
+
+	/**
+	 * Creates a new Datetime instance representing the internal date/time,
+	 * plus the required offset value.
+	 *
+	 * @param {number | Duration | TimeOffset} [timeOffset=0] - The amount to add to the current time.
+	 *
+	 * @returns {Datetime} A new Datetime instance adjusted by the specified offset
+	 */
+	add(timeOffset: number | Duration | TimeOffset): Datetime {
+		let dt: DateTime;
+
+		if (typeof timeOffset === "number") {
+			if (timeOffset < 0) {
+				throw new RangeError("timeOffset must be a positive number");
+			}
+			dt = this.date.plus(timeOffset * 1000);
+		} else {
+			const dur =
+				timeOffset instanceof Duration
+					? timeOffset
+					: Duration.fromObject(timeOffset);
+			if (dur.as("seconds") < 0) {
+				throw new RangeError("timeOffset must be a positive number");
+			}
+			dt = this.date.plus(dur);
+		}
+
+		return new Datetime(dt, {
+			locationTimezone: this.locationTimezone,
+		});
+	}
+
 	/**
 	 * Creates a new Datetime instance representing the internal date/time,
 	 * minus the required offset value.

--- a/src/core/datetime.ts
+++ b/src/core/datetime.ts
@@ -220,7 +220,6 @@ export class Datetime {
 		return this.toLocal(formatString);
 	}
 
-
 	/**
 	 * Creates a new Datetime instance representing the internal date/time,
 	 * plus the required offset value.

--- a/src/core/measurement.ts
+++ b/src/core/measurement.ts
@@ -65,7 +65,6 @@ export class Measurements {
 		if (measurement.coordinates) {
 			this.bounds = updateBounds(measurement.coordinates, this.bounds);
 		}
-
 		if (this.to) {
 			this.to = measurement.timestamp.greaterOf(this.to);
 		} else {

--- a/src/node/client.spec.ts
+++ b/src/node/client.spec.ts
@@ -872,8 +872,37 @@ describe("Client with string responsePath on single resource", () => {
 });
 
 
+describe.only("Client with timeEnding=false throws error when mising averaging interval", () => {
+
+  class JsonClient extends Client {
+		resource = new Resource({ url: "https://blah.org/long" });
+		provider = "testing";
+		longFormat = true;
+		timeEnding = false;
+		xGeometryKey = "longitude";
+		yGeometryKey = "latitude";
+		// averagingIntervalKey = () => 3600
+		sensorStatusKey = () => "asdf";
+		locationIdKey = "station";
+		locationLabelKey = "site_name";
+		geometryProjectionKey = () => "WGS84";
+		ownerKey = () => "test_owner";
+		isMobileKey = () => false;
+		parameters = [
+			{ parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
+			{ parameter: "temperature", unit: "f", key: "tempf" },
+		];
+	}
+
+	test.only("Initiating throws missing property error", async () => {
+	  expect(() => new JsonClient()).toThrowError();
+	});
+
+});
+
 describe("Client with timeEnding=false normalizes timestamps to time-ending", () => {
-	class JsonClient extends Client {
+
+  class JsonClient extends Client {
 		resource = new Resource({ url: "https://blah.org/long" });
 		provider = "testing";
 		longFormat = true;

--- a/src/node/client.spec.ts
+++ b/src/node/client.spec.ts
@@ -870,3 +870,38 @@ describe("Client with string responsePath on single resource", () => {
         expect(data).toStrictEqual(expectedOutput);
     });
 });
+
+
+describe("Client with timeEnding=false normalizes timestamps to time-ending", () => {
+	class JsonClient extends Client {
+		resource = new Resource({ url: "https://blah.org/long" });
+		provider = "testing";
+		longFormat = true;
+		timeEnding = false;
+		xGeometryKey = "longitude";
+		yGeometryKey = "latitude";
+		averagingIntervalKey = () => 3600
+		sensorStatusKey = () => "asdf";
+		locationIdKey = "station";
+		locationLabelKey = "site_name";
+		geometryProjectionKey = () => "WGS84";
+		ownerKey = () => "test_owner";
+		isMobileKey = () => false;
+		parameters = [
+			{ parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
+			{ parameter: "temperature", unit: "f", key: "tempf" },
+		];
+	}
+
+	test("timestamps are shifted forward by averaging interval", async () => {
+		const cln = new JsonClient();
+		const data = await cln.load();
+
+		const timestamps = data.measurements.map((m) => m.timestamp);
+		expect(timestamps).toStrictEqual([
+			"2024-01-01T01:00:00-08:00", // was 00:00
+			"2024-01-01T01:00:00-08:00", // was 00:00
+			"2024-01-01T02:00:00-08:00", // was 01:00
+		]);
+	});
+});

--- a/src/node/client.spec.ts
+++ b/src/node/client.spec.ts
@@ -871,35 +871,6 @@ describe("Client with string responsePath on single resource", () => {
     });
 });
 
-
-describe.only("Client with timeEnding=false throws error when mising averaging interval", () => {
-
-  class JsonClient extends Client {
-		resource = new Resource({ url: "https://blah.org/long" });
-		provider = "testing";
-		longFormat = true;
-		timeEnding = false;
-		xGeometryKey = "longitude";
-		yGeometryKey = "latitude";
-		// averagingIntervalKey = () => 3600
-		sensorStatusKey = () => "asdf";
-		locationIdKey = "station";
-		locationLabelKey = "site_name";
-		geometryProjectionKey = () => "WGS84";
-		ownerKey = () => "test_owner";
-		isMobileKey = () => false;
-		parameters = [
-			{ parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
-			{ parameter: "temperature", unit: "f", key: "tempf" },
-		];
-	}
-
-	test.only("Initiating throws missing property error", async () => {
-	  expect(() => new JsonClient()).toThrowError();
-	});
-
-});
-
 describe("Client with timeEnding=false normalizes timestamps to time-ending", () => {
 
   class JsonClient extends Client {

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -131,6 +131,7 @@ export interface ClientConfiguration {
 	longFormat?: boolean;
 	sourceProjection?: string;
 	datetimeFormat?: string;
+	timeEnding: boolean;
 	secrets?: object;
 
 	locationIdKey?: string | ParseFunction;


### PR DESCRIPTION
adds parameter to client to allow setting timeEnding to automatically adjust time-beginning timestamps to be time-ending, adjusted from the averagingPeriodSecond values.