### PR TITLE
add ability to pass options to parser

### DIFF
--- a/src/core/parsers.spec.ts
+++ b/src/core/parsers.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from 'vitest';
-import { createDelimitedParsers, json, parseDelimited } from './parsers';
+import { createDelimitedParsers, json, parseDelimited, xml } from './parsers';
 
 describe('json parser', () => {
   test('parses valid JSON string', async () => {
@@ -339,5 +339,38 @@ describe('createDelimitedParsers', () => {
 
         await expect(tsv("name\tage\nJohn McCormack\t30")).resolves.not.toThrow();
     });
+  });
+});
+
+
+describe("xml parser", () => {
+  test("parses an XML string into an object", async () => {
+    const result = await xml("<root><name>John McCormack</name></root>", undefined);
+    expect(result).toEqual({ root: { name: "John McCormack" } });
+  });
+
+  test("strips format from options before passing to XMLParser", async () => {
+    const result = await xml("<root/>", { format: "xml" } as any);
+    expect(result).toEqual({ root: "" });
+  });
+
+  test("forwards xmlParserOptions to XMLParser", async () => {
+    const result = await xml(`<root id="1"/>`, {
+      ignoreAttributes: false,
+      attributeNamePrefix: "@_",
+    } as any);
+    expect(result).toEqual({ root: { "@_id": "1" } });
+  });
+
+  test("Single items turns into array when isArray returns true", async () => {
+    const result = await xml(`<root><item>John McCormack</item></root>`, {
+      isArray: (name: string) => name === "item",
+    } as any) as any;
+    expect(result.root.item).toEqual(["John McCormack"]);
+  });
+
+  test("handles undefined options", async () => {
+    const result = await xml("<root/>", undefined);
+    expect(result).toEqual({ root: "" });
   });
 });

--- a/src/core/parsers.spec.ts
+++ b/src/core/parsers.spec.ts
@@ -1,232 +1,343 @@
-import { describe, expect, test, vi } from "vitest";
-import { createDelimitedParsers, json, parseDelimited } from "./parsers";
+import { describe, expect, test, vi } from 'vitest';
+import { createDelimitedParsers, json, parseDelimited } from './parsers';
 
-describe("json parser", () => {
-	test("parses valid JSON string", async () => {
-		const jsonString = '{"name": "foo", "value": 42}';
-		const result = await json(jsonString);
-		expect(result).toEqual({ name: "foo", value: 42 });
-	});
+describe('json parser', () => {
+  test('parses valid JSON string', async () => {
+    const jsonString = '{"name": "foo", "value": 42}';
+    const result = await json(jsonString);
+    expect(result).toEqual({ name: 'foo', value: 42 });
+  });
 
-	test("parses JSON array string", async () => {
-		const jsonString = '[{"id": 1}, {"id": 2}]';
-		const result = await json(jsonString);
-		expect(result).toEqual([{ id: 1 }, { id: 2 }]);
-	});
+  test('parses JSON array string', async () => {
+    const jsonString = '[{"id": 1}, {"id": 2}]';
+    const result = await json(jsonString);
+    expect(result).toEqual([{ id: 1 }, { id: 2 }]);
+  });
 
-	test("returns object as-is when content is already an object", async () => {
-		const obj = { name: "foo", value: 123 };
-		const result = await json(obj);
-		expect(result).toBe(obj);
-	});
+  test('returns object as-is when content is already an object', async () => {
+    const obj = { name: 'foo', value: 123 };
+    const result = await json(obj);
+    expect(result).toBe(obj);
+  });
 
-	test("returns Blob as-is when content is a Blob", async () => {
-		const blob = new Blob(["test"]);
-		const result = await json(blob);
-		expect(result).toBe(blob);
-	});
+  test('returns Blob as-is when content is a Blob', async () => {
+    const blob = new Blob(['test']);
+    const result = await json(blob);
+    expect(result).toBe(blob);
+  });
 
-	test("throws error on invalid JSON string", async () => {
-		const invalidJson = "{invalid json}";
-		await expect(json(invalidJson)).rejects.toThrow();
-	});
+  test('throws error on invalid JSON string', async () => {
+    const invalidJson = '{invalid json}';
+    await expect(json(invalidJson)).rejects.toThrow();
+  });
 
-	test("handles empty JSON object", async () => {
-		const result = await json("{}");
-		expect(result).toEqual({});
-	});
+  test('handles empty JSON object', async () => {
+    const result = await json('{}');
+    expect(result).toEqual({});
+  });
 
-	test("handles empty JSON array", async () => {
-		const result = await json("[]");
-		expect(result).toEqual([]);
-	});
+  test('handles empty JSON array', async () => {
+    const result = await json('[]');
+    expect(result).toEqual([]);
+  });
 
-	test("handles null value", async () => {
-		const result = await json("null");
-		expect(result).toBeNull();
-	});
+  test('handles null value', async () => {
+    const result = await json('null');
+    expect(result).toBeNull();
+  });
 
-	test("handles nested JSON structures", async () => {
-		const nested = '{"outer": {"inner": {"value": 42}}}';
-		const result = await json(nested);
-		expect(result).toEqual({ outer: { inner: { value: 42 } } });
-	});
+  test('handles nested JSON structures', async () => {
+    const nested = '{"outer": {"inner": {"value": 42}}}';
+    const result = await json(nested);
+    expect(result).toEqual({ outer: { inner: { value: 42 } } });
+  });
 
-	test("handles numbers", async () => {
-		const result = await json("42");
-		expect(result).toBe(42);
-	});
+  test('handles numbers', async () => {
+    const result = await json('42');
+    expect(result).toBe(42);
+  });
 
-	test("handles boolean values", async () => {
-		expect(await json("true")).toBe(true);
-		expect(await json("false")).toBe(false);
-	});
+  test('handles boolean values', async () => {
+    expect(await json('true')).toBe(true);
+    expect(await json('false')).toBe(false);
+  });
 
-	test("handles strings with special characters", async () => {
-		const jsonString = '{"message": "Foo\\\\Bar\\t!"}';
-		const result = await json(jsonString);
-		expect(result).toEqual({ message: "Foo\\Bar\t!" });
-	});
+  test('handles strings with special characters', async () => {
+    const jsonString = '{"message": "Foo\\\\Bar\\t!"}';
+    const result = await json(jsonString);
+    expect(result).toEqual({ message: 'Foo\\Bar\t!' });
+  });
 });
 
-describe("parseDelimited", () => {
-	test("calls parse function with string content and options", async () => {
-		const mockParse = vi.fn(() => [{ name: "Del Norte" }]);
-		const options = { columns: true, skip_empty_lines: true };
-		const delimitedText = "name\nDel Norte";
-		const result = await parseDelimited(delimitedText, mockParse, options);
+describe('parseDelimited', () => {
+  test('calls parse function with string content and options', async () => {
+    const mockParse = vi.fn(async () => [{ name: 'Del Norte' }]);
+    const options = { columns: true, skip_empty_lines: true };
+    const delimitedText = 'name\nDel Norte';
+    const result = await parseDelimited(delimitedText, mockParse, options);
 
-		expect(mockParse).toHaveBeenCalledWith(delimitedText, options);
-		expect(result).toEqual([{ name: "Del Norte" }]);
-	});
+    expect(mockParse).toHaveBeenCalledWith(delimitedText, options);
+    expect(result).toEqual([{ name: 'Del Norte' }]);
+  });
 
-	test("handles empty string", async () => {
-		const mockParse = vi.fn(() => []);
-		const options = { columns: true };
+  test('handles empty string', async () => {
+    const mockParse = vi.fn(async () => []);
+    const options = { columns: true };
 
-		const result = await parseDelimited("", mockParse, options);
+    const result = await parseDelimited('', mockParse, options);
 
-		expect(mockParse).toHaveBeenCalledWith("", options);
-		expect(result).toEqual([]);
-	});
+    expect(mockParse).toHaveBeenCalledWith('', options);
+    expect(result).toEqual([]);
+  });
 
-	test("passes through parse function errors", async () => {
-		const mockParse = vi.fn(() => {
-			throw new Error("Parse error");
-		});
-		const options = { columns: true };
+  test('passes through parse function errors', async () => {
+    const mockParse = vi.fn(() => {
+      throw new Error('Parse error');
+    });
+    const options = { columns: true };
 
-		await expect(parseDelimited("invalid", mockParse, options)).rejects.toThrow(
-			"Parse error",
-		);
-	});
+    await expect(parseDelimited('invalid', mockParse, options)).rejects.toThrow(
+      'Parse error',
+    );
+  });
 });
 
-describe("createDelimitedParsers", () => {
-	describe("csv parser", () => {
-		test("parses CSV string with headers", async () => {
-			const mockParse = vi.fn((content, options) => [
-				{ name: "Alice", age: "30" },
-				{ name: "Bob", age: "25" },
-			]);
+describe('createDelimitedParsers', () => {
+  describe('csv parser', () => {
+    test('parses CSV string with headers', async () => {
+      const mockParse = vi.fn(async () => [
+        { name: 'John McCormack', age: '30' },
+        { name: 'Richard Tauber', age: '25' },
+      ]);
 
-			const { csv } = createDelimitedParsers(mockParse);
-			const csvString = "name,age\nAlice,30\nBob,25";
+      const { csv } = createDelimitedParsers(mockParse);
+      const csvString = 'name,age\nJohn McCormack,30\nRichard Tauber,25';
 
-			const result = await csv(csvString);
+      const result = await csv(csvString);
 
-			expect(mockParse).toHaveBeenCalledWith(csvString, {
-				columns: true,
-				skip_empty_lines: true,
-			});
-			expect(result).toEqual([
-				{ name: "Alice", age: "30" },
-				{ name: "Bob", age: "25" },
-			]);
-		});
+      expect(mockParse).toHaveBeenCalledWith(csvString, {
+        columns: true,
+        skip_empty_lines: true,
+      });
+      expect(result).toEqual([
+        { name: 'John McCormack', age: '30' },
+        { name: 'Richard Tauber', age: '25' },
+      ]);
+    });
 
-		test("handles empty CSV string", async () => {
-			const mockParse = vi.fn(() => []);
-			const { csv } = createDelimitedParsers(mockParse);
+    test('handles empty CSV string', async () => {
+      const mockParse = vi.fn(async () => []);
+      const { csv } = createDelimitedParsers(mockParse);
 
-			const result = await csv("");
+      const result = await csv('');
 
-			expect(result).toEqual([]);
-		});
+      expect(result).toEqual([]);
+    });
 
-		test("uses default CSV options", async () => {
-			const mockParse = vi.fn(() => []);
-			const { csv } = createDelimitedParsers(mockParse);
+    test('uses default CSV options', async () => {
+      const mockParse = vi.fn(async () => []);
+      const { csv } = createDelimitedParsers(mockParse);
 
-			await csv("name,age\nAlice,30");
+      await csv('name,age\nJohn McCormack,30');
 
-			expect(mockParse).toHaveBeenCalledWith(
-				expect.any(String),
-				expect.objectContaining({
-					columns: true,
-					skip_empty_lines: true,
-				}),
-			);
-			// Should NOT have delimiter specified (uses default comma)
-			expect(mockParse.mock.calls[0][1]).not.toHaveProperty("delimiter");
-		});
+      expect(mockParse).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          columns: true,
+          skip_empty_lines: true,
+        }),
+      );
+      expect(mockParse.mock.calls[0][1]).not.toHaveProperty('delimiter');
+    });
 
-		test("handles multiline CSV data", async () => {
-			const mockParse = vi.fn(() => [
-				{ name: "Alice", city: "NYC" },
-				{ name: "Bob", city: "LA" },
-				{ name: "Charlie", city: "Chicago" },
-			]);
-			const { csv } = createDelimitedParsers(mockParse);
+    test('handles multiline CSV data', async () => {
+      const mockParse = vi.fn(async () => [
+        { name: 'John McCormack', city: 'Dublin' },
+        { name: 'Richard Tauber', city: 'Linz' },
+        { name: 'Frank Ryan', city: 'Limerick' },
+      ]);
+      const { csv } = createDelimitedParsers(mockParse);
 
-			const csvString = "name,city\nAlice,NYC\nBob,LA\nCharlie,Chicago";
-			const result = await csv(csvString);
+      const csvString =
+        'name,city\nJohn McCormack,Dublin\nRichard Tauber,Linz\nFrank Ryan,Limerick';
+      const result = await csv(csvString);
 
-			expect(result).toHaveLength(3);
-		});
-	});
+      expect(result).toHaveLength(3);
+    });
 
-	describe("tsv parser", () => {
-		test("parses TSV string with headers", async () => {
-			const mockParse = vi.fn((content, options) => [
-				{ name: "Alice", age: "30" },
-				{ name: "Bob", age: "25" },
-			]);
+    test('merges custom options with defaults', async () => {
+      const mockParse = vi.fn().mockResolvedValue([]);
+      const { csv } = createDelimitedParsers(mockParse);
 
-			const { tsv } = createDelimitedParsers(mockParse);
-			const tsvString = "name\tage\nAlice\t30\nBob\t25";
+      await csv('name,age\nJohn McCormack,30', { format: 'csv', cast: true });
 
-			const result = await tsv(tsvString);
+      expect(mockParse).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          columns: true,
+          skip_empty_lines: true,
+          cast: true,
+        }),
+      );
+    });
 
-			expect(mockParse).toHaveBeenCalledWith(tsvString, {
-				delimiter: "\t",
-				columns: true,
-				skip_empty_lines: true,
-			});
-			expect(result).toEqual([
-				{ name: "Alice", age: "30" },
-				{ name: "Bob", age: "25" },
-			]);
-		});
+    test('custom options can override defaults', async () => {
+      const mockParse = vi.fn().mockResolvedValue([]);
+      const { csv } = createDelimitedParsers(mockParse);
 
-		test("uses tab delimiter", async () => {
-			const mockParse = vi.fn(() => []);
-			const { tsv } = createDelimitedParsers(mockParse);
+      await csv('name,age\nJohn McCormack,30', {
+        format: 'csv',
+        columns: false,
+      });
 
-			await tsv("name\tage\nAlice\t30");
+      expect(mockParse).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ columns: false }),
+      );
+    });
 
-			expect(mockParse).toHaveBeenCalledWith(
-				expect.any(String),
-				expect.objectContaining({
-					delimiter: "\t",
-					columns: true,
-					skip_empty_lines: true,
-				}),
-			);
-		});
+    test('strips format field before passing options to parse', async () => {
+      const mockParse = vi.fn().mockResolvedValue([]);
+      const { csv } = createDelimitedParsers(mockParse);
 
-		test("handles empty TSV string", async () => {
-			const mockParse = vi.fn(() => []);
-			const { tsv } = createDelimitedParsers(mockParse);
+      await csv('name,age\nJohn McCormack,30', { format: 'csv' });
 
-			const result = await tsv("");
+      expect(mockParse.mock.calls[0][1]).not.toHaveProperty('format');
+    });
 
-			expect(result).toEqual([]);
-		});
+    test('works without options', async () => {
+      const mockParse = vi.fn().mockResolvedValue([]);
+      const { csv } = createDelimitedParsers(mockParse);
 
-		test("handles TSV with multiple columns", async () => {
-			const mockParse = vi.fn(() => [
-				{ id: "1", name: "Alice", email: "alice@example.com" },
-				{ id: "2", name: "Bob", email: "bob@example.com" },
-			]);
-			const { tsv } = createDelimitedParsers(mockParse);
+      await expect(csv('name,age\nJohn McCormack,30')).resolves.not.toThrow();
+    });
+  });
 
-			const tsvString =
-				"id\tname\temail\n1\tAlice\talice@example.com\n2\tBob\tbob@example.com";
-			const result = await tsv(tsvString);
+  describe('tsv parser', () => {
+    test('parses TSV string with headers', async () => {
+      const mockParse = vi.fn(async () => [
+        { name: 'John McCormack', age: '30' },
+        { name: 'Richard Tauber', age: '25' },
+      ]);
 
-			expect(result).toHaveLength(2);
-			expect(result[0]).toHaveProperty("email");
-		});
-	});
+      const { tsv } = createDelimitedParsers(mockParse);
+      const tsvString = 'name\tage\nJohn McCormack\t30\nRichard Tauber\t25';
+
+      const result = await tsv(tsvString);
+
+      expect(mockParse).toHaveBeenCalledWith(tsvString, {
+        delimiter: '\t',
+        columns: true,
+        skip_empty_lines: true,
+      });
+      expect(result).toEqual([
+        { name: 'John McCormack', age: '30' },
+        { name: 'Richard Tauber', age: '25' },
+      ]);
+    });
+
+    test('uses tab delimiter', async () => {
+      const mockParse = vi.fn(async () => []);
+      const { tsv } = createDelimitedParsers(mockParse);
+
+      await tsv('name\tage\nJohn McCormack\t30');
+
+      expect(mockParse).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          delimiter: '\t',
+          columns: true,
+          skip_empty_lines: true,
+        }),
+      );
+    });
+
+    test('handles empty TSV string', async () => {
+      const mockParse = vi.fn(async () => []);
+      const { tsv } = createDelimitedParsers(mockParse);
+
+      const result = await tsv('');
+
+      expect(result).toEqual([]);
+    });
+
+    test('handles TSV with multiple columns', async () => {
+      const mockParse = vi.fn(async () => [
+        {
+          id: '1',
+          name: 'John McCormack',
+          email: 'john.mccormack@example.com',
+        },
+        {
+          id: '2',
+          name: 'Richard Tauber',
+          email: 'richard.tauber@example.com',
+        },
+      ]);
+      const { tsv } = createDelimitedParsers(mockParse);
+
+      const tsvString =
+        'id\tname\temail\n1\John McCormack\tjohn.mccormack@example.com\n2\tRichard Tauber\trichard.tauber@example.com';
+      const result = await tsv(tsvString);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toHaveProperty('email');
+    });
+
+	 test("custom delimiter option does not override tab", async () => {
+        const mockParse = vi.fn().mockResolvedValue([]);
+        const { tsv } = createDelimitedParsers(mockParse);
+
+        await tsv("name\tage\nJohn McCormack\t30", { format: "tsv", delimiter: "," });
+
+        expect(mockParse).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ delimiter: "\t" }),
+        );
+    });
+
+    test("warns when non-tab delimiter is passed", async () => {
+        const mockParse = vi.fn().mockResolvedValue([]);
+        const { tsv } = createDelimitedParsers(mockParse);
+        const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+        await tsv("name\tage\nJohn McCormack\t30", { format: "tsv", delimiter: "," });
+
+        expect(mockParse.mock.calls[0][1]).toHaveProperty("delimiter", "\t");
+        warnSpy.mockRestore();
+    });
+
+    test("merges custom options while keeping tab delimiter", async () => {
+        const mockParse = vi.fn().mockResolvedValue([]);
+        const { tsv } = createDelimitedParsers(mockParse);
+
+        await tsv("name\tage\nJohn McCormack\t30", { format: "tsv", cast: true });
+
+        expect(mockParse).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({
+                delimiter: "\t",
+                columns: true,
+                skip_empty_lines: true,
+                cast: true,
+            }),
+        );
+    });
+
+    test("strips format field before passing options to parse", async () => {
+        const mockParse = vi.fn().mockResolvedValue([]);
+        const { tsv } = createDelimitedParsers(mockParse);
+
+        await tsv("name\tage\nJohn McCormack\t30", { format: "tsv" });
+
+        expect(mockParse.mock.calls[0][1]).not.toHaveProperty("format");
+    });
+
+    test("works without options", async () => {
+        const mockParse = vi.fn().mockResolvedValue([]);
+        const { tsv } = createDelimitedParsers(mockParse);
+
+        await expect(tsv("name\tage\nJohn McCormack\t30")).resolves.not.toThrow();
+    });
+  });
 });

--- a/src/core/parsers.ts
+++ b/src/core/parsers.ts
@@ -1,5 +1,5 @@
+import type { Options as CsvParseOptions } from "csv-parse";
 import debug from "debug";
-import type { Options as CsvParseOptions } from 'csv-parse';
 import { XMLParser } from "fast-xml-parser";
 import type { SourceRecord } from "../types/data";
 import type {
@@ -13,7 +13,6 @@ import type {
 const log = debug("openaq-transform:parsers");
 const warn = debug("openaq-transform:parsers:warn");
 
-
 export const parseDelimited = async (
 	content: string,
 	parse: CsvParseFunction,
@@ -23,13 +22,18 @@ export const parseDelimited = async (
 };
 
 export const createDelimitedParsers = (parse: CsvParseFunction) => {
-	const csv: StringParser<SourceRecord[]>  = async (content: string, options) => {
+	const csv: StringParser<SourceRecord[]> = async (
+		content: string,
+		options,
+	) => {
 		log(`Parsing ${typeof content} data using the csv method`);
 		const { format, ...csvOptions } = (options as DelimitedParserOptions) ?? {};
 
 		if (csvOptions.delimiter && csvOptions.delimiter !== ",") {
-        	warn(`${format} parser received delimiter "${csvOptions.delimiter}", delimiter is fixed to "," and will not be overwritten`);
-    	}
+			warn(
+				`${format} parser received delimiter "${csvOptions.delimiter}", delimiter is fixed to "," and will not be overwritten`,
+			);
+		}
 
 		return parseDelimited(content, parse, {
 			columns: true,
@@ -38,14 +42,19 @@ export const createDelimitedParsers = (parse: CsvParseFunction) => {
 		});
 	};
 
-	const tsv: StringParser<SourceRecord[]>  = async (content: string, options) => {
+	const tsv: StringParser<SourceRecord[]> = async (
+		content: string,
+		options,
+	) => {
 		log(`Parsing ${typeof content} data using the tsv method`);
 		const { format, ...tsvOptions } = (options as DelimitedParserOptions) ?? {};
 
 		if (tsvOptions.delimiter && tsvOptions.delimiter !== "\t") {
-        	warn(`${format} parser received delimiter "${tsvOptions.delimiter}", delimiter is fixed to "\\t" and will not be overwritten`);
-    	}
-    
+			warn(
+				`${format} parser received delimiter "${tsvOptions.delimiter}", delimiter is fixed to "\\t" and will not be overwritten`,
+			);
+		}
+
 		return parseDelimited(content, parse, {
 			columns: true,
 			skip_empty_lines: true,

--- a/src/core/parsers.ts
+++ b/src/core/parsers.ts
@@ -1,14 +1,18 @@
-import type { Options as CsvParseOptions } from "csv-parse";
 import debug from "debug";
-import { type X2jOptions, XMLParser } from "fast-xml-parser";
+import type { Options as CsvParseOptions } from 'csv-parse';
+import { XMLParser } from "fast-xml-parser";
 import type { SourceRecord } from "../types/data";
 import type {
 	CsvParseFunction,
+	DelimitedParserOptions,
 	JsonParser,
 	StringParser,
+	XmlParserOptions,
 } from "../types/parsers";
 
-const log = debug("openaq-transform parsers: DEBUG");
+const log = debug("openaq-transform:parsers");
+const warn = debug("openaq-transform:parsers:warn");
+
 
 export const parseDelimited = async (
 	content: string,
@@ -19,20 +23,34 @@ export const parseDelimited = async (
 };
 
 export const createDelimitedParsers = (parse: CsvParseFunction) => {
-	const csv = async (content: string) => {
+	const csv: StringParser<SourceRecord[]>  = async (content: string, options) => {
 		log(`Parsing ${typeof content} data using the csv method`);
+		const { format, ...csvOptions } = (options as DelimitedParserOptions) ?? {};
+
+		if (csvOptions.delimiter && csvOptions.delimiter !== ",") {
+        	warn(`${format} parser received delimiter "${csvOptions.delimiter}", delimiter is fixed to "," and will not be overwritten`);
+    	}
+
 		return parseDelimited(content, parse, {
 			columns: true,
 			skip_empty_lines: true,
+			...csvOptions,
 		});
 	};
 
-	const tsv = async (content: string) => {
+	const tsv: StringParser<SourceRecord[]>  = async (content: string, options) => {
 		log(`Parsing ${typeof content} data using the tsv method`);
+		const { format, ...tsvOptions } = (options as DelimitedParserOptions) ?? {};
+
+		if (tsvOptions.delimiter && tsvOptions.delimiter !== "\t") {
+        	warn(`${format} parser received delimiter "${tsvOptions.delimiter}", delimiter is fixed to "\\t" and will not be overwritten`);
+    	}
+    
 		return parseDelimited(content, parse, {
-			delimiter: "\t",
 			columns: true,
 			skip_empty_lines: true,
+			...tsvOptions,
+			delimiter: "\t",
 		});
 	};
 
@@ -52,9 +70,10 @@ export const json: JsonParser<SourceRecord | SourceRecord[]> = async (
 
 export const xml: StringParser<SourceRecord | SourceRecord[]> = async (
 	content,
-	options: X2jOptions = {},
+	options,
 ) => {
 	log(`Parsing ${typeof content} data using the xml method`);
-	const parser = new XMLParser(options);
+	const { format, ...xmlParserOptions } = (options as XmlParserOptions) ?? {};
+	const parser = new XMLParser(xmlParserOptions);
 	return parser.parse(content) as SourceRecord | SourceRecord[];
 };

--- a/src/core/readers.ts
+++ b/src/core/readers.ts
@@ -167,12 +167,13 @@ export async function apiReader(
 ): Promise<unknown | unknown[] | Record<string, unknown>> {
 	resource.data = data;
 
-	const options = resource.options as UrlReaderOptions;
+	const readerOptions = resource.readerOptions as UrlReaderOptions;
+	const parserOptions = resource.parserOptions;
 
 	// overrides default if needed
 	const fetchOptions: UrlReaderOptions = {
 		method: "GET",
-		...options,
+		...readerOptions,
 	};
 
 	const urls = resource.urls;
@@ -250,11 +251,11 @@ export async function apiReader(
 				try {
 					let result: unknown;
 					if (raw.readAs === "text") {
-						result = await (parser as StringParser)(raw.content);
+						result = await (parser as StringParser)(raw.content, parserOptions);
 					} else if (raw.readAs === "blob") {
-						result = await (parser as BlobParser)(raw.content);
+						result = await (parser as BlobParser)(raw.content, parserOptions);
 					} else {
-						result = await (parser as JsonParser)(raw.content);
+						result = await (parser as JsonParser)(raw.content, parserOptions);
 					}
 
 					if (!result || typeof result !== "object") {

--- a/src/core/resource.spec.ts
+++ b/src/core/resource.spec.ts
@@ -281,10 +281,10 @@ test("resource with Bearer auth returns no header when token is absent", () => {
   expect(resource.headers).toStrictEqual(new Headers({}));
 });
 
-test("Bearer auth header overwrite over Authorization header from options", () => {
+test("Bearer auth header overwrite over Authorization header from readerOptions", () => {
   const resource = new Resource({
     url: "https://example.com",
-    options: { headers: { Authorization: "Bearer oldtoken" } },
+    readerOptions: { headers: { Authorization: "Bearer oldtoken" } },
     auth: { type: "Bearer", token: "newtoken" }
   });
   expect(resource.headers).toStrictEqual(new Headers({ Authorization: "Bearer newtoken" }));

--- a/src/core/resource.ts
+++ b/src/core/resource.ts
@@ -13,6 +13,7 @@ import {
 	type Body,
 	isAuthValueFunction,
 } from "../types/resource";
+import { KnownParserOptions, ParserOptions } from "../types/parsers";
 
 type Parameters = Record<string, string | number | boolean>;
 
@@ -60,7 +61,8 @@ type ResourceConfig =
 			output?: ResourceOutput;
 			readAs?: ReadAs;
 			auth?: Auth;
-			options?: ReaderOptions;
+			readerOptions?: ReaderOptions;
+			parserOptions?: KnownParserOptions | ParserOptions;
 			strict?: boolean;
 	  }
 	| {
@@ -72,7 +74,8 @@ type ResourceConfig =
 			output?: ResourceOutput;
 			readAs?: ReadAs;
 			auth?: Auth;
-			options?: ReaderOptions;
+			readerOptions?: ReaderOptions;
+			parserOptions?: KnownParserOptions | ParserOptions;
 			strict?: boolean;
 	  };
 
@@ -110,7 +113,8 @@ export class Resource {
 	#readAs?: ReadAs;
 	#strict: boolean;
 	#auth?: Auth;
-	#options?: UrlReaderOptions;
+	#readerOptions?: UrlReaderOptions;
+	#parserOptions?: KnownParserOptions | ParserOptions;
 
 	constructor(config: ResourceConfig) {
 		this.validateConfig(config);
@@ -124,7 +128,8 @@ export class Resource {
 		this.#readAs = config.readAs;
 		this.#strict = config.strict ?? false;
 		this.#auth = config.auth;
-		this.#options = config.options;
+		this.#readerOptions = config.readerOptions;
+		this.#parserOptions = config.parserOptions;
 	}
 
 	private validateConfig(config: unknown): asserts config is ResourceConfig {
@@ -264,8 +269,8 @@ export class Resource {
 	get headers(): Headers {
 		const merged = new Headers();
 
-		if (this.#options?.headers) {
-			for (const [key, value] of Object.entries(this.#options.headers)) {
+		if (this.#readerOptions?.headers) {
+			for (const [key, value] of Object.entries(this.#readerOptions.headers)) {
 				merged.set(key, typeof value === "function" ? value() : value);
 			}
 		}
@@ -277,11 +282,16 @@ export class Resource {
 		return merged;
 	}
 
-	get options(): ReaderOptions {
+	get readerOptions(): ReaderOptions {
 		return {
-			...this.#options,
+			...this.#readerOptions,
 			headers: this.headers,
 		};
+	}
+
+
+	get parserOptions(): KnownParserOptions | ParserOptions | undefined {
+		return this.#parserOptions;
 	}
 
 	set auth(auth: Auth) {

--- a/src/core/resource.ts
+++ b/src/core/resource.ts
@@ -1,6 +1,7 @@
 import { type JSONValue, search } from "@jmespath-community/jmespath";
 import type { PathExpression } from "../types";
 import { isPathExpression } from "../types/metric";
+import type { KnownParserOptions, ParserOptions } from "../types/parsers";
 import type {
 	DataContext,
 	ReadAs,
@@ -13,7 +14,6 @@ import {
 	type Body,
 	isAuthValueFunction,
 } from "../types/resource";
-import { KnownParserOptions, ParserOptions } from "../types/parsers";
 
 type Parameters = Record<string, string | number | boolean>;
 
@@ -288,7 +288,6 @@ export class Resource {
 			headers: this.headers,
 		};
 	}
-
 
 	get parserOptions(): KnownParserOptions | ParserOptions | undefined {
 		return this.#parserOptions;

--- a/src/node/readers.ts
+++ b/src/node/readers.ts
@@ -12,6 +12,8 @@ export const fileSystemReader = async (
 		throw new TypeError("fileSystemReader requires a URL-based resource");
 	}
 
+	const parserOptions = resource.parserOptions;
+
 	const results = await Promise.all(
 		resource.urls.map(({ url }) => {
 			const path = url.startsWith("file://") ? new URL(url) : url;
@@ -21,7 +23,7 @@ export const fileSystemReader = async (
 	);
 
 	const content = results.join("\n");
-	const result: unknown = await parser(content);
+	const result: unknown = await parser(content, parserOptions);
 
 	if (!result || typeof result !== "object") {
 		throw new Error("Parser returned a non-object value");

--- a/src/types/parsers.ts
+++ b/src/types/parsers.ts
@@ -1,26 +1,109 @@
-import type { Options as CsvParseOptions } from "csv-parse";
-import type { SourceRecord } from "./data";
-import type { ResourceKeys } from "./resource";
+import type { Options as CsvParseOptions } from 'csv-parse';
+import type { SourceRecord } from './data';
+import type { ResourceKeys } from './resource';
+import { X2jOptions } from 'fast-xml-parser';
+
+
+/**
+ * Base interface for all parser option objects.
+ *
+ * @example
+ * export interface MyParserOptions extends ParserOptions {
+ *   format: "my-format";
+ *   customField?: string;
+ * }
+ */
+export interface ParserOptions {
+  format: string;
+}
+
+/**
+ * Parser options for XML parser, passed directly to the underlying
+ * `fast-xml-parser` XMLParser instance.
+ *
+ * All `X2jOptions` from `fast-xml-parser` are accepted via the index
+ * signature, refer to that library's documentation for the full option set.
+ *
+ * @see {@link https://github.com/NaturalIntelligence/fast-xml-parser/blob/master/docs/v4%2C%20v5/2.XMLparseOptions.md}
+ *
+ * @example
+ * // RSS feed example ensure <item> and <category> are always arrays
+ * const options: XmlParserOptions = {
+ *   format: "xml",
+ *   isArray: (tagName) => ["item", "category"].includes(tagName),
+ * };
+ *
+ * @example
+ * // Atom feed example use jPath to avoid over-matching <link> in <head>
+ * const options: XmlParserOptions = {
+ *   format: "xml",
+ *   isArray: (tagName, jPath) =>
+ *     ["entry", "author", "category"].includes(tagName) ||
+ *     jPath.endsWith("feed.entry.link"),
+ * };
+ */
+export interface XmlParserOptions extends ParserOptions, X2jOptions {
+    format: "xml";
+}
+
+/**
+ * Parser options for delimiter-separated value content (csv, tsv, etc.).
+ *
+ * Extends `csv-parse`'s `Options` directly, all upstream options are
+ * available and passed through to the parser unchanged. The fields declared
+ * here are the commonly used subset.
+ *
+ * @see {@link https://csv.js.org/parse/options/}
+ *
+ * @example
+ * // Standard comma-separated file with a header row
+ * const options: DelimitedParserOptions = {
+ *   format: "csv",
+ *   delimiter: ",",
+ *   columns: true,
+ *   skip_empty_lines: true,
+ * };
+ *
+ * @example
+ * // tab separated file, casting numeric columns automatically
+ * const options: DelimitedParserOptions = {
+ *   format: "tsv",
+ *   delimiter: "\t",
+ *   columns: true,
+ *   cast: true,
+ * };
+ */
+export interface DelimitedParserOptions extends ParserOptions, CsvParseOptions {
+    format: "csv" | "tsv" | "psv" | "ssv" | (string & {});
+    delimiter?: string;
+    columns?: boolean;
+    skip_empty_lines?: boolean;
+}
+
+export type KnownParserOptions = XmlParserOptions | DelimitedParserOptions;
 
 export type CsvParseFunction = (
-	input: string | Buffer,
-	options?: CsvParseOptions,
+  input: string | Buffer,
+  options?: CsvParseOptions,
 ) => Promise<SourceRecord[]>;
 
-export type StringParser<T = unknown> = (content: string) => Promise<T> | T;
-export type JsonParser<T = unknown> = (content: unknown) => Promise<T> | T;
-export type BlobParser<T = unknown> = (content: Blob) => Promise<T> | T;
-
 // biome-ignore lint/suspicious/noExplicitAny: Content type must be any to allow storage of parsers with different content types in registries
-export type Parser<T = unknown> = (content: any) => Promise<T> | T;
+export type Parser<T = unknown, TContent = any> = (
+  content: TContent,
+  options?: ParserOptions | KnownParserOptions,
+) => Promise<T> | T;
+
+export type StringParser<T = unknown> = Parser<T, string>;
+export type JsonParser<T = unknown> = Parser<T, unknown>;
+export type BlobParser<T = unknown> = Parser<T, Blob>;
 
 export function isParser(value: unknown): value is Parser {
-	return typeof value === "function";
+  return typeof value === 'function';
 }
 
 export type IndexedParser<T> = Partial<Record<ResourceKeys, keyof T | Parser>>;
 
 export type ParserMethods = {
-	// biome-ignore lint/suspicious/noExplicitAny: Parser registry must accommodate parsers with different content and return types
-	[key: string]: Parser<any>;
+  // biome-ignore lint/suspicious/noExplicitAny: Parser registry must accommodate parsers with different content and return types
+  [key: string]: Parser<any>;
 };

--- a/src/types/parsers.ts
+++ b/src/types/parsers.ts
@@ -1,8 +1,7 @@
-import type { Options as CsvParseOptions } from 'csv-parse';
-import type { SourceRecord } from './data';
-import type { ResourceKeys } from './resource';
-import { X2jOptions } from 'fast-xml-parser';
-
+import type { Options as CsvParseOptions } from "csv-parse";
+import type { X2jOptions } from "fast-xml-parser";
+import type { SourceRecord } from "./data";
+import type { ResourceKeys } from "./resource";
 
 /**
  * Base interface for all parser option objects.
@@ -14,7 +13,7 @@ import { X2jOptions } from 'fast-xml-parser';
  * }
  */
 export interface ParserOptions {
-  format: string;
+	format: string;
 }
 
 /**
@@ -43,7 +42,7 @@ export interface ParserOptions {
  * };
  */
 export interface XmlParserOptions extends ParserOptions, X2jOptions {
-    format: "xml";
+	format: "xml";
 }
 
 /**
@@ -74,23 +73,23 @@ export interface XmlParserOptions extends ParserOptions, X2jOptions {
  * };
  */
 export interface DelimitedParserOptions extends ParserOptions, CsvParseOptions {
-    format: "csv" | "tsv" | "psv" | "ssv" | (string & {});
-    delimiter?: string;
-    columns?: boolean;
-    skip_empty_lines?: boolean;
+	format: "csv" | "tsv" | "psv" | "ssv" | (string & {});
+	delimiter?: string;
+	columns?: boolean;
+	skip_empty_lines?: boolean;
 }
 
 export type KnownParserOptions = XmlParserOptions | DelimitedParserOptions;
 
 export type CsvParseFunction = (
-  input: string | Buffer,
-  options?: CsvParseOptions,
+	input: string | Buffer,
+	options?: CsvParseOptions,
 ) => Promise<SourceRecord[]>;
 
 // biome-ignore lint/suspicious/noExplicitAny: Content type must be any to allow storage of parsers with different content types in registries
 export type Parser<T = unknown, TContent = any> = (
-  content: TContent,
-  options?: ParserOptions | KnownParserOptions,
+	content: TContent,
+	options?: ParserOptions | KnownParserOptions,
 ) => Promise<T> | T;
 
 export type StringParser<T = unknown> = Parser<T, string>;
@@ -98,12 +97,12 @@ export type JsonParser<T = unknown> = Parser<T, unknown>;
 export type BlobParser<T = unknown> = Parser<T, Blob>;
 
 export function isParser(value: unknown): value is Parser {
-  return typeof value === 'function';
+	return typeof value === "function";
 }
 
 export type IndexedParser<T> = Partial<Record<ResourceKeys, keyof T | Parser>>;
 
 export type ParserMethods = {
-  // biome-ignore lint/suspicious/noExplicitAny: Parser registry must accommodate parsers with different content and return types
-  [key: string]: Parser<any>;
+	// biome-ignore lint/suspicious/noExplicitAny: Parser registry must accommodate parsers with different content and return types
+	[key: string]: Parser<any>;
 };


### PR DESCRIPTION
Resolves #75 


updates `Resource` to take a `parserOptions` and renames `options` to `readerOptions` for consistency  e.g. 

```ts
new Resource({
    ...
    parserOptions:  {
        format: "xml",
        isArray: (name) => name === 'foo'
    }
    ...
}) 
```