### PR TITLE
add constantValue type

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Parameters can also be a JMESPath expression evaluated against the same
 ```ts
 new Resource({
   url: 'https://api.example.com/locations/:id/measurements',
-  parameters: { type: 'jmespath', expression: 'locations[*].{id: id}' }
+  parameters: { type: 'jmespath', value: 'locations[*].{id: id}' }
 })
 ```
 

--- a/src/browser/client.spec.ts
+++ b/src/browser/client.spec.ts
@@ -22,15 +22,15 @@ test("test environment", () => {
 // this is what is needed to parse the provided data correctly
 class CustomClient extends Client {
 	provider = "testing";
-	xGeometryKey = "longitude";
-	averagingIntervalKey = "averaging";
-	sensorStatusKey = () => "asdf";
-	yGeometryKey = "latitude";
-	locationIdKey = "station";
-	locationLabelKey = "site_name";
-	projectionKey = () => "WSG84";
-	ownerKey = () => "test_owner";
-	isMobileKey = () => false;
+	xGeometry = "longitude";
+	averagingInterval = "averaging";
+	sensorStatus = () => "asdf";
+	yGeometry = "latitude";
+	locationId = "station";
+	locationLabel = "site_name";
+	projection = () => "WSG84";
+	owner = () => "test_owner";
+	isMobile = () => false;
 	parameters = [
 		{ parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
 		{ parameter: "temperature", unit: "f", key: "tempf" },

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -5,6 +5,7 @@ import {
 	type ClientInfoKey,
 	type ClientParser,
 	type ClientReader,
+	type ConstantValue,
 	type IndexedResource,
 	type IngestMatchingMethod,
 	isIndexed,
@@ -68,32 +69,49 @@ export abstract class Client<
 	// source: Source;
 	timezone?: string;
 	longFormat: boolean = false;
-	geometryProjectionKey: string | PathExpression | ParseFunction = "projection";
+	geometryProjectionKey:
+		| string
+		| PathExpression
+		| ConstantValue
+		| ParseFunction = "projection";
 	datetimeFormat: string = "yyyy-MM-dd'T'HH:mm:ssZZ";
 	timeEnding: boolean = true;
 
 	// mapped data variables
-	locationIdKey: string | PathExpression | ParseFunction = "location";
-	locationLabelKey: string | PathExpression | ParseFunction = "label";
+	locationIdKey: string | PathExpression | ConstantValue | ParseFunction =
+		"location";
+	locationLabelKey: string | PathExpression | ConstantValue | ParseFunction =
+		"label";
 	// if longFormat = false this value is ignored
-	parameterNameKey: string | PathExpression | ParseFunction = "parameter";
-	parameterValueKey: string | PathExpression | ParseFunction = "value";
-	flagsKey: string | PathExpression | ParseFunction = "flags";
+	parameterNameKey: string | PathExpression | ConstantValue | ParseFunction =
+		"parameter";
+	parameterValueKey: string | PathExpression | ConstantValue | ParseFunction =
+		"value";
+	flagsKey: string | PathExpression | ConstantValue | ParseFunction = "flags";
 	numberFormat: DecimalDigitGroup = { decimal: "point" };
-	yGeometryKey: string | PathExpression | ParseFunction = "y";
-	xGeometryKey: string | PathExpression | ParseFunction = "x";
-	manufacturerKey: string | PathExpression | ParseFunction =
+	yGeometryKey: string | PathExpression | ConstantValue | ParseFunction = "y";
+	xGeometryKey: string | PathExpression | ConstantValue | ParseFunction = "x";
+	manufacturerKey: string | PathExpression | ConstantValue | ParseFunction =
 		"manufacturer_name";
-	modelKey: string | PathExpression | ParseFunction = "model_name";
-	ownerKey: string | PathExpression | ParseFunction = "owner_name";
-	datetimeKey: string | PathExpression | ParseFunction = "datetime";
-	licenseKey: string | PathExpression | ParseFunction = "license";
-	isMobileKey: string | PathExpression | ParseFunction = "is_mobile";
-	loggingIntervalKey: string | PathExpression | ParseFunction =
+	modelKey: string | PathExpression | ConstantValue | ParseFunction =
+		"model_name";
+	ownerKey: string | PathExpression | ConstantValue | ParseFunction =
+		"owner_name";
+	datetimeKey: string | PathExpression | ConstantValue | ParseFunction =
+		"datetime";
+	licenseKey: string | PathExpression | ConstantValue | ParseFunction =
+		"license";
+	isMobileKey: string | PathExpression | ConstantValue | ParseFunction =
+		"is_mobile";
+	loggingIntervalKey: string | PathExpression | ConstantValue | ParseFunction =
 		"logging_interval_seconds";
-	averagingIntervalKey: string | PathExpression | ParseFunction =
-		"averaging_interval_seconds";
-	sensorStatusKey: string | PathExpression | ParseFunction = "status";
+	averagingIntervalKey:
+		| string
+		| PathExpression
+		| ConstantValue
+		| ParseFunction = "averaging_interval_seconds";
+	sensorStatusKey: string | PathExpression | ConstantValue | ParseFunction =
+		"status";
 	providerFlags?: ValueFlagMap = FLAG_DEFAULTS;
 	ingestMatchingMethod: IngestMatchingMethod = "ingest-id";
 
@@ -106,7 +124,7 @@ export abstract class Client<
 
 	protected getNumber = (
 		data: SourceRecord,
-		key: string | PathExpression | ParseFunction,
+		key: string | PathExpression | ConstantValue | ParseFunction,
 	) => getNumber(data, key, this.numberFormat);
 
 	#startedOn?: Datetime;
@@ -800,8 +818,9 @@ export abstract class Client<
 		// if we provided a parameter column key we use that
 		// otherwise we use the list of parameters
 		// the end goal is just an array of parameter names to loop through
-		const params: Array<string | PathExpression | ParseFunction> = this
-			.longFormat
+		const params: Array<
+			string | PathExpression | ConstantValue | ParseFunction
+		> = this.longFormat
 			? // for long format we will just pass the parameter name key and use that each time
 				[this.parameterNameKey]
 			: this.measurements.parameterKeys();
@@ -1072,19 +1091,19 @@ export abstract class Client<
 	 */
 	info(): ClientInfo {
 		const translateKey = (
-			key: string | PathExpression | ParseFunction,
+			key: string | PathExpression | ConstantValue | ParseFunction,
 		): ClientInfoKey => {
 			let type: ClientInfoKey["type"];
-			let value: string | undefined;
+			let value: string | number | undefined;
 			if (typeof key === "function") {
 				type = "function";
 				value = String(getValueFromKey({}, key));
 			} else if (typeof key === "string") {
 				type = "field";
 				value = key;
-			} else if (typeof key === "object" && "expression" in key) {
-				type = "jmespath";
-				value = key.expression;
+			} else if (typeof key === "object" && "value" in key) {
+				type = key.type;
+				value = key.value;
 			} else {
 				type = "field";
 				value = undefined;

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -69,48 +69,49 @@ export abstract class Client<
 	// source: Source;
 	timezone?: string;
 	longFormat: boolean = false;
-	geometryProjectionKey:
-		| string
-		| PathExpression
-		| ConstantValue
-		| ParseFunction = "projection";
+	geometryProjection: string | PathExpression | ConstantValue | ParseFunction =
+		"projection";
 	datetimeFormat: string = "yyyy-MM-dd'T'HH:mm:ssZZ";
 	timeEnding: boolean = true;
 
 	// mapped data variables
-	locationIdKey: string | PathExpression | ConstantValue | ParseFunction =
+	locationId: string | PathExpression | ConstantValue | ParseFunction =
 		"location";
-	locationLabelKey: string | PathExpression | ConstantValue | ParseFunction =
+	locationLabel: string | PathExpression | ConstantValue | ParseFunction =
 		"label";
 	// if longFormat = false this value is ignored
-	parameterNameKey: string | PathExpression | ConstantValue | ParseFunction =
+	parameterName: string | PathExpression | ConstantValue | ParseFunction =
 		"parameter";
-	parameterValueKey: string | PathExpression | ConstantValue | ParseFunction =
+	parameterValue: string | PathExpression | ConstantValue | ParseFunction =
 		"value";
-	flagsKey: string | PathExpression | ConstantValue | ParseFunction = "flags";
+	flags: string | PathExpression | ConstantValue | ParseFunction = "flags";
 	numberFormat: DecimalDigitGroup = { decimal: "point" };
-	yGeometryKey: string | PathExpression | ConstantValue | ParseFunction = "y";
-	xGeometryKey: string | PathExpression | ConstantValue | ParseFunction = "x";
-	manufacturerKey: string | PathExpression | ConstantValue | ParseFunction =
+	yGeometry: string | PathExpression | ConstantValue | ParseFunction | number =
+		"y";
+	xGeometry: string | PathExpression | ConstantValue | ParseFunction | number =
+		"x";
+	manufacturer: string | PathExpression | ConstantValue | ParseFunction =
 		"manufacturer_name";
-	modelKey: string | PathExpression | ConstantValue | ParseFunction =
-		"model_name";
-	ownerKey: string | PathExpression | ConstantValue | ParseFunction =
-		"owner_name";
-	datetimeKey: string | PathExpression | ConstantValue | ParseFunction =
+	model: string | PathExpression | ConstantValue | ParseFunction = "model_name";
+	owner: string | PathExpression | ConstantValue | ParseFunction = "owner_name";
+	datetime: string | PathExpression | ConstantValue | ParseFunction =
 		"datetime";
-	licenseKey: string | PathExpression | ConstantValue | ParseFunction =
-		"license";
-	isMobileKey: string | PathExpression | ConstantValue | ParseFunction =
+	license: string | PathExpression | ConstantValue | ParseFunction = "license";
+	isMobile: string | PathExpression | ConstantValue | ParseFunction | boolean =
 		"is_mobile";
-	loggingIntervalKey: string | PathExpression | ConstantValue | ParseFunction =
-		"logging_interval_seconds";
-	averagingIntervalKey:
+	loggingInterval:
 		| string
 		| PathExpression
 		| ConstantValue
-		| ParseFunction = "averaging_interval_seconds";
-	sensorStatusKey: string | PathExpression | ConstantValue | ParseFunction =
+		| ParseFunction
+		| number = "logging_interval_seconds";
+	averagingInterval:
+		| string
+		| PathExpression
+		| ConstantValue
+		| ParseFunction
+		| number = "averaging_interval_seconds";
+	sensorStatus: string | PathExpression | ConstantValue | ParseFunction =
 		"status";
 	providerFlags?: ValueFlagMap = FLAG_DEFAULTS;
 	ingestMatchingMethod: IngestMatchingMethod = "ingest-id";
@@ -124,7 +125,7 @@ export abstract class Client<
 
 	protected getNumber = (
 		data: SourceRecord,
-		key: string | PathExpression | ConstantValue | ParseFunction,
+		key: string | number | PathExpression | ConstantValue | ParseFunction,
 	) => getNumber(data, key, this.numberFormat);
 
 	#startedOn?: Datetime;
@@ -180,63 +181,63 @@ export abstract class Client<
 			this.parser = this.#params.parser;
 		}
 		// mapped data variables
-		if (this.#params?.locationIdKey) {
-			this.locationIdKey = this.#params.locationIdKey;
+		if (this.#params?.locationId) {
+			this.locationId = this.#params.locationId;
 		}
-		if (this.#params?.locationLabelKey) {
-			this.locationLabelKey = this.#params.locationLabelKey;
+		if (this.#params?.locationLabel) {
+			this.locationLabel = this.#params.locationLabel;
 		}
 		// these are used for long format
-		if (this.#params?.parameterNameKey) {
-			this.parameterNameKey = this.#params.parameterNameKey;
+		if (this.#params?.parameterName) {
+			this.parameterName = this.#params.parameterName;
 		}
-		if (this.#params?.parameterValueKey) {
-			this.parameterValueKey = this.#params.parameterValueKey;
+		if (this.#params?.parameterValue) {
+			this.parameterValue = this.#params.parameterValue;
 		}
-		if (this.#params?.flagsKey) {
-			this.flagsKey = this.#params.flagsKey;
+		if (this.#params?.flags) {
+			this.flags = this.#params.flags;
 		}
 		if (this.#params?.numberFormat) {
 			this.numberFormat = this.#params.numberFormat;
 		}
-		if (this.#params?.yGeometryKey) {
-			this.yGeometryKey = this.#params.yGeometryKey;
+		if (this.#params?.yGeometry) {
+			this.yGeometry = this.#params.yGeometry;
 		}
-		if (this.#params?.xGeometryKey) {
-			this.xGeometryKey = this.#params.xGeometryKey;
+		if (this.#params?.xGeometry) {
+			this.xGeometry = this.#params.xGeometry;
 		}
-		if (this.#params?.geometryProjectionKey) {
-			this.geometryProjectionKey = this.#params.geometryProjectionKey;
+		if (this.#params?.geometryProjection) {
+			this.geometryProjection = this.#params.geometryProjection;
 		}
-		if (this.#params?.manufacturerKey) {
-			this.manufacturerKey = this.#params.manufacturerKey;
+		if (this.#params?.manufacturer) {
+			this.manufacturer = this.#params.manufacturer;
 		}
-		if (this.#params?.modelKey) {
-			this.modelKey = this.#params.modelKey;
+		if (this.#params?.model) {
+			this.model = this.#params.model;
 		}
-		if (this.#params?.ownerKey) {
-			this.ownerKey = this.#params.ownerKey;
+		if (this.#params?.owner) {
+			this.owner = this.#params.owner;
 		}
-		if (this.#params?.datetimeKey) {
-			this.datetimeKey = this.#params.datetimeKey;
+		if (this.#params?.datetime) {
+			this.datetime = this.#params.datetime;
 		}
 		if (this.#params?.timeEnding !== undefined) {
 			this.timeEnding = this.#params.timeEnding;
 		}
-		if (this.#params?.licenseKey) {
-			this.licenseKey = this.#params.licenseKey;
+		if (this.#params?.license) {
+			this.license = this.#params.license;
 		}
-		if (this.#params?.isMobileKey) {
-			this.isMobileKey = this.#params.isMobileKey;
+		if (this.#params?.isMobile) {
+			this.isMobile = this.#params.isMobile;
 		}
-		if (this.#params?.loggingIntervalKey) {
-			this.loggingIntervalKey = this.#params.loggingIntervalKey;
+		if (this.#params?.loggingInterval) {
+			this.loggingInterval = this.#params.loggingInterval;
 		}
-		if (this.#params?.averagingIntervalKey) {
-			this.averagingIntervalKey = this.#params.averagingIntervalKey;
+		if (this.#params?.averagingInterval) {
+			this.averagingInterval = this.#params.averagingInterval;
 		}
-		if (this.#params?.sensorStatusKey) {
-			this.sensorStatusKey = this.#params.sensorStatusKey;
+		if (this.#params?.sensorStatus) {
+			this.sensorStatus = this.#params.sensorStatus;
 		}
 		if (this.#params?.ingestMatchingMethod) {
 			this.ingestMatchingMethod = this.#params.ingestMatchingMethod;
@@ -441,11 +442,11 @@ export abstract class Client<
 		row: SourceRecord,
 		averagingIntervalSeconds: number | undefined,
 	): Datetime {
-		const dtString = getValueFromKey(row, this.datetimeKey);
+		const dtString = getValueFromKey(row, this.datetime);
 		log(`getDatetime`, dtString);
 		if (typeof dtString !== "string" || !dtString) {
 			throw new Error(
-				`Missing date/time field. Looking in ${formatValueForLog(this.datetimeKey)}`,
+				`Missing date/time field. Looking in ${formatValueForLog(this.datetime)}`,
 			);
 		}
 		let dt = new Datetime(dtString, {
@@ -681,7 +682,7 @@ export abstract class Client<
 	 * Add a location to our list
 	 */
 	getLocation(data: SourceRecord) {
-		const siteId = getString(data, this.locationIdKey) ?? "";
+		const siteId = getString(data, this.locationId) ?? "";
 		// BUILDING KEY
 		const key = Location.createKey({ provider: this.provider, siteId });
 
@@ -693,19 +694,16 @@ export abstract class Client<
 				...data,
 				siteId,
 				provider: this.provider,
-				siteName: getString(data, this.locationLabelKey) ?? "",
-				ismobile: getBoolean(data, this.isMobileKey),
-				x: this.getNumber(data, this.xGeometryKey),
-				y: this.getNumber(data, this.yGeometryKey),
-				projection: getString(data, this.geometryProjectionKey),
-				averagingIntervalSeconds: this.getNumber(
-					data,
-					this.averagingIntervalKey,
-				),
-				loggingIntervalSeconds: this.getNumber(data, this.loggingIntervalKey),
-				status: getString(data, this.sensorStatusKey) ?? "",
-				owner: getString(data, this.ownerKey) ?? "",
-				label: getString(data, this.locationLabelKey) ?? "",
+				siteName: getString(data, this.locationLabel) ?? "",
+				ismobile: getBoolean(data, this.isMobile),
+				x: this.getNumber(data, this.xGeometry),
+				y: this.getNumber(data, this.yGeometry),
+				projection: getString(data, this.geometryProjection),
+				averagingIntervalSeconds: this.getNumber(data, this.averagingInterval),
+				loggingIntervalSeconds: this.getNumber(data, this.loggingInterval),
+				status: getString(data, this.sensorStatus) ?? "",
+				owner: getString(data, this.owner) ?? "",
+				label: getString(data, this.locationLabel) ?? "",
 			});
 			this.#locations.add(location);
 		}
@@ -741,7 +739,7 @@ export abstract class Client<
 	}
 
 	private getSensor(data: SourceRecord): Sensor {
-		const metricName = getValueFromKey(data, this.parameterNameKey) as string;
+		const metricName = getValueFromKey(data, this.parameterName) as string;
 		const metric =
 			(data.metric as Metric | undefined) ??
 			this.measurements.metricFromProviderKey(metricName);
@@ -753,15 +751,12 @@ export abstract class Client<
 		// get or add then get the location
 		const location = this.getLocation(data);
 
-		const status =
-			getString(data, this.sensorStatusKey) ?? location.sensorStatus;
+		const status = getString(data, this.sensorStatus) ?? location.sensorStatus;
 
 		// maintain a way to get the sensor back without traversing everything
 
-		const manufacturerName = cleanKey(
-			getValueFromKey(data, this.manufacturerKey),
-		);
-		const modelName = cleanKey(getValueFromKey(data, this.modelKey));
+		const manufacturerName = cleanKey(getValueFromKey(data, this.manufacturer));
+		const modelName = cleanKey(getValueFromKey(data, this.model));
 		const versionDate = cleanKey(data.version_date);
 		const instance = cleanKey(data.instance);
 
@@ -788,10 +783,10 @@ export abstract class Client<
 				systemKey: system.key,
 				metric,
 				averagingIntervalSeconds:
-					this.getNumber(data, this.averagingIntervalKey) ??
+					this.getNumber(data, this.averagingInterval) ??
 					location.averagingIntervalSeconds,
 				loggingIntervalSeconds:
-					this.getNumber(data, this.loggingIntervalKey) ??
+					this.getNumber(data, this.loggingInterval) ??
 					location.loggingIntervalSeconds,
 				versionDate,
 				instance,
@@ -822,7 +817,7 @@ export abstract class Client<
 			string | PathExpression | ConstantValue | ParseFunction
 		> = this.longFormat
 			? // for long format we will just pass the parameter name key and use that each time
-				[this.parameterNameKey]
+				[this.parameterName]
 			: this.measurements.parameterKeys();
 
 		measurements.forEach((measurementRow: SourceRecord) => {
@@ -834,11 +829,11 @@ export abstract class Client<
 						? getValueFromKey(measurementRow, p)
 						: p;
 
-					const valueName = this.longFormat ? this.parameterValueKey : p;
+					const valueName = this.longFormat ? this.parameterValue : p;
 
 					const value = getValueFromKey(measurementRow, valueName);
 					// flags must be an array so we need to check that somewhere
-					const flags = getArray(measurementRow, this.flagsKey)?.map((f) => {
+					const flags = getArray(measurementRow, this.flags)?.map((f) => {
 						if (this.providerFlags?.has(f)) {
 							return this.providerFlags.get(f);
 						} else {
@@ -913,7 +908,7 @@ export abstract class Client<
 		log(`Processing ${flags.length} flags`);
 		flags.forEach((d: SourceRecord) => {
 			try {
-				const metric = getValueFromKey(d, this.parameterNameKey);
+				const metric = getValueFromKey(d, this.parameterName);
 				const sensor = this.getSensor({
 					metric,
 					...d,
@@ -1091,10 +1086,16 @@ export abstract class Client<
 	 */
 	info(): ClientInfo {
 		const translateKey = (
-			key: string | PathExpression | ConstantValue | ParseFunction,
+			key:
+				| string
+				| number
+				| boolean
+				| PathExpression
+				| ConstantValue
+				| ParseFunction,
 		): ClientInfoKey => {
 			let type: ClientInfoKey["type"];
-			let value: string | number | undefined;
+			let value: string | number | boolean | undefined;
 			if (typeof key === "function") {
 				type = "function";
 				value = String(getValueFromKey({}, key));
@@ -1113,20 +1114,20 @@ export abstract class Client<
 
 		return {
 			provider: this.provider,
-			datetimeKey: translateKey(this.datetimeKey),
+			datetime: translateKey(this.datetime),
 			timezone: this.timezone,
 			datetimeFormat: this.datetimeFormat,
-			geometryProjectionKey: translateKey(this.geometryProjectionKey),
-			yGeometryKey: translateKey(this.yGeometryKey),
-			xGeometryKey: translateKey(this.xGeometryKey),
-			manufacturerKey: translateKey(this.manufacturerKey),
-			modelKey: translateKey(this.modelKey),
-			ownerKey: translateKey(this.ownerKey),
-			licenseKey: translateKey(this.licenseKey),
+			geometryProjection: translateKey(this.geometryProjection),
+			yGeometry: translateKey(this.yGeometry),
+			xGeometry: translateKey(this.xGeometry),
+			manufacturer: translateKey(this.manufacturer),
+			model: translateKey(this.model),
+			owner: translateKey(this.owner),
+			license: translateKey(this.license),
 			isLongFormat: this.longFormat,
-			isMobile: translateKey(this.isMobileKey),
-			loggingInterval: translateKey(this.loggingIntervalKey),
-			averagingInterval: translateKey(this.averagingIntervalKey),
+			isMobile: translateKey(this.isMobile),
+			loggingInterval: translateKey(this.loggingInterval),
+			averagingInterval: translateKey(this.averagingInterval),
 			ingestMatchingMethod: this.ingestMatchingMethod,
 			parameters: this.parameters.map((p) => ({
 				parameter: p.parameter,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,4 +1,15 @@
-export type { PathExpression } from "../types";
+export type {
+	ClientConfiguration,
+	ConstantValue,
+	DecimalDigitGroup,
+	PathExpression,
+	ResourceKeys,
+} from "../types";
+
 export { Datetime } from "./datetime";
 
+export { FetchError, ParseError, TransformError } from "./errors";
+
 export { Resource } from "./resource";
+
+export { constant, jmespath } from "./utils";

--- a/src/core/resource.spec.ts
+++ b/src/core/resource.spec.ts
@@ -73,7 +73,7 @@ test("resource with jmespath and data works", () => {
 	];
 	const resource = new Resource({
 		url: "https://example.com/locations/:locationsId",
-		parameters: { type: "jmespath", expression: "[0].locations" },
+		parameters: { type: "jmespath", value: "[0].locations" },
 	});
 	resource.data = data;
 	const urls = resource.urls;

--- a/src/core/resource.ts
+++ b/src/core/resource.ts
@@ -440,7 +440,7 @@ export class Resource {
 			if (this.#parameters.type === "jmespath") {
 				const value = search(
 					this.#data as unknown as JSONValue,
-					this.#parameters.expression,
+					this.#parameters.value,
 				);
 				return value as Parameters[];
 			} else {

--- a/src/core/utils.spec.ts
+++ b/src/core/utils.spec.ts
@@ -12,7 +12,8 @@ import {
   getArray,
   getValueFromKey,
 } from './utils.ts';
-import { DecimalDigitGroup } from '../types/client.ts';
+import { DecimalDigitGroup } from '../types/metric.ts';
+import { ConstantValue } from '../types/client.ts';
 
 test('cleanKey replaces only if value is truthy', () => {
   expect(cleanKey('')).toBe('');
@@ -53,18 +54,28 @@ test('getValueFromKey throws for unsafe optional property access', () => {
 test('getValueFromKey returns value when using jmespath expression', () => {
   const pathExpression = {
     type: 'jmespath',
-    expression: '$.measurements[0].pm25',
+    value: '$.measurements[0].pm25',
   } satisfies PathExpression;
   expect(
     getValueFromKey({ measurements: [{ pm25: 42 }] }, pathExpression),
   ).toBe(42);
 });
 
+test('getValueFromKey returns value when using constant value', () => {
+  const constantValue = {
+    type: 'constant',
+    value: 3600,
+  } satisfies ConstantValue;
+  expect(
+    getValueFromKey({ measurements: [{ pm25: 42 }] }, constantValue),
+  ).toBe(3600);
+});
+
 test('getValueFromKey throws when unsupported expression type is passed', () => {
   // @ts-expect-error Testing unsupported type value
   const pathExpression = {
     type: 'xpath',
-    expression: '/measurements[0]/pm25',
+    value: '/measurements[0]/pm25',
   } satisfies PathExpression;
   // @ts-expect-error Testing unsupported type value
   expect(() =>
@@ -151,6 +162,18 @@ describe('getString', () => {
   test('returns empty string for empty string', () => {
     expect(getString(record(''), key)).toBe('');
   });
+
+  test('returns a string for jmespath expression', () => {
+    expect(getString(record(42), {type: "jmespath", value: "value"})).toBe('42');
+  });
+
+  test('returns a string for constant value of type string', () => {
+    expect(getString(record(42), {type: "constant", value: "2"})).toBe('2');
+  });
+
+  test('returns a string for constant value of type number', () => {
+    expect(getString(record(42), {type: "constant", value: 2})).toBe('2');
+  });
 });
 
 describe('getNumber', () => {
@@ -182,6 +205,18 @@ describe('getNumber', () => {
 
   test("returns 0 for '0'", () => {
     expect(getNumber(record('0'), key, numberFormat)).toBe(0);
+  });
+
+  test("returns number 0 for jmespath expression", () => {
+    expect(getNumber(record('0'), { type: 'jmespath', value: 'value' }, numberFormat)).toBe(0);
+  });
+
+  test("returns constant number for constant value string", () => {
+    expect(getNumber(record('0'), { type: 'constant', value: '42' }, numberFormat)).toBe(42);
+  });
+
+    test("returns constant number for constant value number", () => {
+    expect(getNumber(record('0'), { type: 'constant', value: 42 }, numberFormat)).toBe(42);
   });
 
   test('parses a comma-decimal string with matching numberFormat', () => {
@@ -259,6 +294,13 @@ describe('getArray tests', () => {
     expect(getArray(record([]), key)).toStrictEqual([]);
   });
 
+  test('returns array for path expression', () => {
+    expect(getArray(record('some-value'), {type: 'jmespath', value: 'value'} satisfies PathExpression)).toStrictEqual(['some-value']);
+  });
+
+  test('returns array for constant value', () => {
+    expect(getArray(record('some-value'), {type: 'constant', value: 42} satisfies ConstantValue)).toStrictEqual([42]);
+  });
 });
 
 // Test cases based on "common" cases as described in the table here:

--- a/src/core/utils.spec.ts
+++ b/src/core/utils.spec.ts
@@ -11,6 +11,8 @@ import {
   getString,
   getArray,
   getValueFromKey,
+  constant,
+  jmespath,
 } from './utils.ts';
 import { DecimalDigitGroup } from '../types/metric.ts';
 import { ConstantValue } from '../types/client.ts';
@@ -66,9 +68,9 @@ test('getValueFromKey returns value when using constant value', () => {
     type: 'constant',
     value: 3600,
   } satisfies ConstantValue;
-  expect(
-    getValueFromKey({ measurements: [{ pm25: 42 }] }, constantValue),
-  ).toBe(3600);
+  expect(getValueFromKey({ measurements: [{ pm25: 42 }] }, constantValue)).toBe(
+    3600,
+  );
 });
 
 test('getValueFromKey throws when unsupported expression type is passed', () => {
@@ -85,8 +87,26 @@ test('getValueFromKey throws when unsupported expression type is passed', () => 
 
 test('getValueFromKey returns null when key function throws a non-TypeError', () => {
   expect(
-    getValueFromKey({ pm25: 42 }, () => { throw new Error('unexpected'); })
+    getValueFromKey({ pm25: 42 }, () => {
+      throw new Error('unexpected');
+    }),
   ).toBe(null);
+});
+
+test('getValueFromKey returns boolean true primitive directly', () => {
+  expect(getValueFromKey({ is_mobile: false }, true)).toBe(true);
+});
+
+test('getValueFromKey returns boolean false primitive directly', () => {
+  expect(getValueFromKey({ is_mobile: true }, false)).toBe(false);
+});
+
+test('getValueFromKey returns number primitive directly', () => {
+  expect(getValueFromKey({ interval: 42 }, 3600)).toBe(3600);
+});
+
+test('getValueFromKey returns zero number primitive directly', () => {
+  expect(getValueFromKey({ interval: 42 }, 0)).toBe(0);
 });
 
 test('countDecimals returns the right value', () => {
@@ -142,7 +162,7 @@ test('countDecimals returns the right value', () => {
 // });
 
 const record = (value: unknown) => ({ value }) as unknown as SourceRecord;
-const key = "value";
+const key = 'value';
 
 describe('getString', () => {
   test('returns the string value as-is', () => {
@@ -170,15 +190,17 @@ describe('getString', () => {
   });
 
   test('returns a string for jmespath expression', () => {
-    expect(getString(record(42), {type: "jmespath", value: "value"})).toBe('42');
+    expect(getString(record(42), { type: 'jmespath', value: 'value' })).toBe(
+      '42',
+    );
   });
 
   test('returns a string for constant value of type string', () => {
-    expect(getString(record(42), {type: "constant", value: "2"})).toBe('2');
+    expect(getString(record(42), { type: 'constant', value: '2' })).toBe('2');
   });
 
   test('returns a string for constant value of type number', () => {
-    expect(getString(record(42), {type: "constant", value: 2})).toBe('2');
+    expect(getString(record(42), { type: 'constant', value: 2 })).toBe('2');
   });
 });
 
@@ -213,16 +235,34 @@ describe('getNumber', () => {
     expect(getNumber(record('0'), key, numberFormat)).toBe(0);
   });
 
-  test("returns number 0 for jmespath expression", () => {
-    expect(getNumber(record('0'), { type: 'jmespath', value: 'value' }, numberFormat)).toBe(0);
+  test('returns number 0 for jmespath expression', () => {
+    expect(
+      getNumber(
+        record('0'),
+        { type: 'jmespath', value: 'value' },
+        numberFormat,
+      ),
+    ).toBe(0);
   });
 
-  test("returns constant number for constant value string", () => {
-    expect(getNumber(record('0'), { type: 'constant', value: '42' }, numberFormat)).toBe(42);
+  test('returns constant number for constant value string', () => {
+    expect(
+      getNumber(record('0'), { type: 'constant', value: '42' }, numberFormat),
+    ).toBe(42);
   });
 
-    test("returns constant number for constant value number", () => {
-    expect(getNumber(record('0'), { type: 'constant', value: 42 }, numberFormat)).toBe(42);
+  test('returns constant number for constant value number', () => {
+    expect(
+      getNumber(record('0'), { type: 'constant', value: 42 }, numberFormat),
+    ).toBe(42);
+  });
+
+  test('returns number primitive directly', () => {
+    expect(getNumber(record(42), 3600, numberFormat)).toBe(3600);
+  });
+
+  test('returns zero number primitive directly', () => {
+    expect(getNumber(record(42), 0, numberFormat)).toBe(0);
   });
 
   test('parses a comma-decimal string with matching numberFormat', () => {
@@ -275,6 +315,14 @@ describe('getBoolean', () => {
   test('returns true for a non-empty arbitrary string', () => {
     expect(getBoolean(record('some-value'), key)).toBe(true);
   });
+
+  test('returns true when key is literal true', () => {
+    expect(getBoolean(record(false), true)).toBe(true);
+  });
+
+  test('returns false when key is literal false', () => {
+    expect(getBoolean(record(true), false)).toBe(false);
+  });
 });
 
 describe('getArray tests', () => {
@@ -301,163 +349,228 @@ describe('getArray tests', () => {
   });
 
   test('returns array for path expression', () => {
-    expect(getArray(record('some-value'), {type: 'jmespath', value: 'value'} satisfies PathExpression)).toStrictEqual(['some-value']);
+    expect(
+      getArray(record('some-value'), {
+        type: 'jmespath',
+        value: 'value',
+      } satisfies PathExpression),
+    ).toStrictEqual(['some-value']);
   });
 
   test('returns array for constant value', () => {
-    expect(getArray(record('some-value'), {type: 'constant', value: 42} satisfies ConstantValue)).toStrictEqual([42]);
+    expect(
+      getArray(record('some-value'), {
+        type: 'constant',
+        value: 42,
+      } satisfies ConstantValue),
+    ).toStrictEqual([42]);
   });
 });
 
 // Test cases based on "common" cases as described in the table here:
 // https://en.wikipedia.org/wiki/Decimal_separator#Other_numeral_systems
 
-describe("normalizeNumericString", () => {
+describe('normalizeNumericString', () => {
+  describe('comma grouped, point decimal', () => {
+    const format: DecimalDigitGroup = { decimal: 'point', digitGroup: 'comma' };
 
-	describe("comma grouped, point decimal", () => {
-		const format: DecimalDigitGroup = { decimal: "point", digitGroup: "comma" };
- 
-		test("parses a fully-formatted number", () => {
-			expect(normalizeNumericString("1,234,567.89", format)).toBe("1234567.89");
-		});
- 
-		test("parses an integer with group separators", () => {
-			expect(normalizeNumericString("1,234,567", format)).toBe("1234567");
-		});
- 
-		test("parses a number without group separator", () => {
-			expect(normalizeNumericString("1234567.89", format)).toBe("1234567.89");
-		});
- 
-		test("parses zero", () => {
-			expect(normalizeNumericString("0.00", format)).toBe("0.00");
-		});
- 
-		test("parses a negative number", () => {
-			expect(normalizeNumericString("-1,234.56", format)).toBe("-1234.56");
-		});
- 
-		test("returns empty string for empty input", () => {
-			expect(normalizeNumericString("  ", format)).toBe("");
-		});
-	});
- 
+    test('parses a fully-formatted number', () => {
+      expect(normalizeNumericString('1,234,567.89', format)).toBe('1234567.89');
+    });
 
-	describe("no group, point decimal", () => {
-		const format: DecimalDigitGroup = { decimal: "point" };
- 
-		test("parses a plain integer", () => {
-			expect(normalizeNumericString("1234567", format)).toBe("1234567");
-		});
- 
-		test("parses a number with decimal part", () => {
-			expect(normalizeNumericString("1234567.89", format)).toBe("1234567.89");
-		});
- 
-		test("returns empty string for empty input", () => {
-			expect(normalizeNumericString("", format)).toBe("");
-		});
-	});
- 
+    test('parses an integer with group separators', () => {
+      expect(normalizeNumericString('1,234,567', format)).toBe('1234567');
+    });
 
-	describe("no group, comma decimal", () => {
-		const format: DecimalDigitGroup = { decimal: "comma" };
- 
-		test("parses a plain number and converts comma to period", () => {
-			expect(normalizeNumericString("1234567,89", format)).toBe("1234567.89");
-		});
- 
-		test("parses an integer", () => {
-			expect(normalizeNumericString("1234567", format)).toBe("1234567");
-		});
-	});
+    test('parses a number without group separator', () => {
+      expect(normalizeNumericString('1234567.89', format)).toBe('1234567.89');
+    });
 
-	describe("dot grouped, comma decimal", () => {
-		const format: DecimalDigitGroup = { decimal: "comma", digitGroup: "dot" };
- 
-		test("parses a comma decimal got grouped number", () => {
-			expect(normalizeNumericString("1.234.567,89", format)).toBe("1234567.89");
-		});
- 
-		test("parses an integer with dot separators", () => {
-			expect(normalizeNumericString("1.234.567", format)).toBe("1234567");
-		});
- 
-		test("parses a small number", () => {
-			expect(normalizeNumericString("1.000,00", format)).toBe("1000.00");
-		});
+    test('parses zero', () => {
+      expect(normalizeNumericString('0.00', format)).toBe('0.00');
+    });
 
-	});
- 
-	describe("comma grouped, interpunct decimal", () => {
-		const format: DecimalDigitGroup = { decimal: "interpunct", digitGroup: "comma" };
- 
-		test("parses a interpunct comma grouped number", () => {
-			expect(normalizeNumericString("1,234,567\u00B789", format)).toBe("1234567.89");
-		});
- 
-		test("parses without group separator", () => {
-			expect(normalizeNumericString("1234567\u00B789", format)).toBe("1234567.89");
-		});
-	});
- 
-	describe("Indian number grouping", () => {
-		const format: DecimalDigitGroup = { decimal: "point", digitGroup: "comma" };
- 
-		test("parses Indian-style grouping", () => {
-			expect(normalizeNumericString("12,34,567.89", format)).toBe("1234567.89");
-		});
-	});
- 
-	describe("apostrophe grouped, point decimal", () => {
-		const format: DecimalDigitGroup = { decimal: "point", digitGroup: "apostrophe" };
- 
-		test("parses an apostrophe grouped point decimal number", () => {
-			expect(normalizeNumericString("1'234'567.89", format)).toBe("1234567.89");
-		});
- 
-		test("parses an integer with apostrophe groups", () => {
-			expect(normalizeNumericString("1'234'567", format)).toBe("1234567");
-		});
-	});
- 
-	describe("apostrophe grouped, comma decimal", () => {
-		const format: DecimalDigitGroup = { decimal: "comma", digitGroup: "apostrophe" };
- 
-		test("parses an apostophe grouped comma decimal number", () => {
-			expect(normalizeNumericString("1'234'567,89", format)).toBe("1234567.89");
-		});
+    test('parses a negative number', () => {
+      expect(normalizeNumericString('-1,234.56', format)).toBe('-1234.56');
+    });
 
-    test("parses an integer with apostrophe groups", () => {
-			expect(normalizeNumericString("1'234'567", format)).toBe("1234567");
-		});
-	});
- 
-	describe("space grouped, comma decimal", () => {
-		const format: DecimalDigitGroup = { decimal: "comma", digitGroup: "space" };
- 
-		test("parses space as group separator", () => {
-			expect(normalizeNumericString("1 234 567,89", format)).toBe("1234567.89");
-		});
- 
-		test("parses non-breaking space (U+00A0) as group separator", () => {
-			expect(normalizeNumericString("1\u00A0234\u00A0567,89", format)).toBe("1234567.89");
-		});
- 
-		test("parses narrow no-break space (U+202F) as group separator", () => {
-			expect(normalizeNumericString("1\u202F234\u202F567,89", format)).toBe("1234567.89");
-		});
- 
-		test("parses an integer with space separators", () => {
-			expect(normalizeNumericString("1 234 567", format)).toBe("1234567");
-		});
-	});
- 
-	describe("arabic decimal separator (U+066B)", () => {
-		const format: DecimalDigitGroup = { decimal: "arabic" };
- 
-		test("parses a number with arabic decimal comma", () => {
-			expect(normalizeNumericString("1234567\u066B89", format)).toBe("1234567.89");
-		});
-	});
+    test('returns empty string for empty input', () => {
+      expect(normalizeNumericString('  ', format)).toBe('');
+    });
+  });
+
+  describe('no group, point decimal', () => {
+    const format: DecimalDigitGroup = { decimal: 'point' };
+
+    test('parses a plain integer', () => {
+      expect(normalizeNumericString('1234567', format)).toBe('1234567');
+    });
+
+    test('parses a number with decimal part', () => {
+      expect(normalizeNumericString('1234567.89', format)).toBe('1234567.89');
+    });
+
+    test('returns empty string for empty input', () => {
+      expect(normalizeNumericString('', format)).toBe('');
+    });
+  });
+
+  describe('no group, comma decimal', () => {
+    const format: DecimalDigitGroup = { decimal: 'comma' };
+
+    test('parses a plain number and converts comma to period', () => {
+      expect(normalizeNumericString('1234567,89', format)).toBe('1234567.89');
+    });
+
+    test('parses an integer', () => {
+      expect(normalizeNumericString('1234567', format)).toBe('1234567');
+    });
+  });
+
+  describe('dot grouped, comma decimal', () => {
+    const format: DecimalDigitGroup = { decimal: 'comma', digitGroup: 'dot' };
+
+    test('parses a comma decimal got grouped number', () => {
+      expect(normalizeNumericString('1.234.567,89', format)).toBe('1234567.89');
+    });
+
+    test('parses an integer with dot separators', () => {
+      expect(normalizeNumericString('1.234.567', format)).toBe('1234567');
+    });
+
+    test('parses a small number', () => {
+      expect(normalizeNumericString('1.000,00', format)).toBe('1000.00');
+    });
+  });
+
+  describe('comma grouped, interpunct decimal', () => {
+    const format: DecimalDigitGroup = {
+      decimal: 'interpunct',
+      digitGroup: 'comma',
+    };
+
+    test('parses a interpunct comma grouped number', () => {
+      expect(normalizeNumericString('1,234,567\u00B789', format)).toBe(
+        '1234567.89',
+      );
+    });
+
+    test('parses without group separator', () => {
+      expect(normalizeNumericString('1234567\u00B789', format)).toBe(
+        '1234567.89',
+      );
+    });
+  });
+
+  describe('Indian number grouping', () => {
+    const format: DecimalDigitGroup = { decimal: 'point', digitGroup: 'comma' };
+
+    test('parses Indian-style grouping', () => {
+      expect(normalizeNumericString('12,34,567.89', format)).toBe('1234567.89');
+    });
+  });
+
+  describe('apostrophe grouped, point decimal', () => {
+    const format: DecimalDigitGroup = {
+      decimal: 'point',
+      digitGroup: 'apostrophe',
+    };
+
+    test('parses an apostrophe grouped point decimal number', () => {
+      expect(normalizeNumericString("1'234'567.89", format)).toBe('1234567.89');
+    });
+
+    test('parses an integer with apostrophe groups', () => {
+      expect(normalizeNumericString("1'234'567", format)).toBe('1234567');
+    });
+  });
+
+  describe('apostrophe grouped, comma decimal', () => {
+    const format: DecimalDigitGroup = {
+      decimal: 'comma',
+      digitGroup: 'apostrophe',
+    };
+
+    test('parses an apostophe grouped comma decimal number', () => {
+      expect(normalizeNumericString("1'234'567,89", format)).toBe('1234567.89');
+    });
+
+    test('parses an integer with apostrophe groups', () => {
+      expect(normalizeNumericString("1'234'567", format)).toBe('1234567');
+    });
+  });
+
+  describe('space grouped, comma decimal', () => {
+    const format: DecimalDigitGroup = { decimal: 'comma', digitGroup: 'space' };
+
+    test('parses space as group separator', () => {
+      expect(normalizeNumericString('1 234 567,89', format)).toBe('1234567.89');
+    });
+
+    test('parses non-breaking space (U+00A0) as group separator', () => {
+      expect(normalizeNumericString('1\u00A0234\u00A0567,89', format)).toBe(
+        '1234567.89',
+      );
+    });
+
+    test('parses narrow no-break space (U+202F) as group separator', () => {
+      expect(normalizeNumericString('1\u202F234\u202F567,89', format)).toBe(
+        '1234567.89',
+      );
+    });
+
+    test('parses an integer with space separators', () => {
+      expect(normalizeNumericString('1 234 567', format)).toBe('1234567');
+    });
+  });
+
+  describe('arabic decimal separator (U+066B)', () => {
+    const format: DecimalDigitGroup = { decimal: 'arabic' };
+
+    test('parses a number with arabic decimal comma', () => {
+      expect(normalizeNumericString('1234567\u066B89', format)).toBe(
+        '1234567.89',
+      );
+    });
+  });
+});
+
+describe('jmespath()', () => {
+  test('Creates a PathExpression', () => {
+    const result = jmespath('device.logging.interval');
+
+    expect(result).toEqual({
+      type: 'jmespath',
+      value: 'device.logging.interval',
+    });
+  });
+});
+
+describe('constant()', () => {
+  test('Create a ConstantValue with a number', () => {
+    const result = constant(3600);
+
+    expect(result).toEqual({
+      type: 'constant',
+      value: 3600,
+    });
+  });
+
+  test('Create a ConstantValue with a string', () => {
+    const result = constant('foo');
+
+    expect(result).toEqual({
+      type: 'constant',
+      value: 'foo',
+    });
+  });
+
+  test('Create a ConstantValue with a boolean', () => {
+    const result = constant(true);
+
+    expect(result).toEqual({
+      type: 'constant',
+      value: true,
+    });
+  });
 });

--- a/src/core/utils.spec.ts
+++ b/src/core/utils.spec.ts
@@ -83,6 +83,12 @@ test('getValueFromKey throws when unsupported expression type is passed', () => 
   ).toThrow(TypeError);
 });
 
+test('getValueFromKey returns null when key function throws a non-TypeError', () => {
+  expect(
+    getValueFromKey({ pm25: 42 }, () => { throw new Error('unexpected'); })
+  ).toBe(null);
+});
+
 test('countDecimals returns the right value', () => {
   expect(countDecimals(7.24)).toBe(2);
 });

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -38,10 +38,6 @@ export const getValueFromKey = (
 				log(`getting value from key using ${key.value}`);
 				const value = search(data as unknown as JSONValue, key.value);
 				return value;
-			} else {
-				throw TypeError(
-					`TypeError: unsupported path expression type, supported syntaxes include: jmespath`,
-				);
 			}
 		}
 		if (isConstantValue(key)) {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -28,9 +28,30 @@ export const stripNulls = <T extends object>(
 	);
 };
 
+/**
+ * Extracts a value from a source record using a variety of key types.
+ *
+ * @param data - The source record to extract a value from.
+ * @param key - Describes how to extract the value. Accepts:
+ *   - `string` — used as a direct property key on `data`
+ *   - `number` — returned as-is (constant passthrough)
+ * 	 - `boolean` — returned as-is (constant passthrough)
+ *   - `ParseFunction` — called with `data`
+ *   - `ConstantValue` — the `value` attribute is returned as-is (constant passthrough)
+ *   - `PathExpression` — `jmespath` query evaluated against `data`
+ * @returns The extracted value, or `null` if no matching key type was found.
+ * @throws {Error} If a `ParseFunction` throws a `TypeError` during execution.
+ * @throws {TypeError} If a `PathExpression` has an unsupported `type`.
+ */
 export const getValueFromKey = (
 	data: SourceRecord,
-	key: ParseFunction | string | ConstantValue | PathExpression,
+	key:
+		| ParseFunction
+		| string
+		| number
+		| boolean
+		| ConstantValue
+		| PathExpression,
 ) => {
 	if (isStructuredKey(key)) {
 		if (isPathExpression(key)) {
@@ -63,6 +84,8 @@ export const getValueFromKey = (
 		log(`getting value from key using '${key}'`);
 		const value = data ? data[key] : key;
 		return value;
+	} else if (typeof key === "number" || typeof key === "boolean") {
+		return key;
 	}
 	return null;
 };
@@ -77,8 +100,15 @@ export const cleanKey = (value: unknown): string | undefined => {
 };
 
 /**
- * Count the number of decimal places in value
- * @returns number
+ * Counts the number of decimal places in a number.
+ *
+ * @param value - The number to count.
+ * @returns The number of digits after the decimal point, or `0` for integers.
+ *
+ * @example
+ * countDecimals(3.14)  // 2
+ * countDecimals(100)   // 0
+ * countDecimals(1.5)   // 1
  */
 export function countDecimals(value: number) {
 	if (Math.floor(value.valueOf()) === value.valueOf()) return 0;
@@ -112,6 +142,13 @@ export function formatValueForLog(value: unknown): string {
 	return `[${typeof value}]`;
 }
 
+/**
+ * Extracts a value from a source record and coerces it to a string.
+ *
+ * @param data - The source record to extract a value from.
+ * @param key - Key describing how to extract the value; see {@link getValueFromKey}.
+ * @returns The extracted value as a string, or `undefined` if the value is `null` or `undefined`.
+ */
 export const getString = (
 	data: SourceRecord,
 	key: ParseFunction | string | ConstantValue | PathExpression,
@@ -121,9 +158,22 @@ export const getString = (
 	return String(value);
 };
 
+/**
+ * Extracts a value from a source record and coerces it to a number.
+ *
+ * String values are normalized before parsing using {@link normalizeNumericString},
+ * which handles locale-specific decimal and digit-group separators.
+ * Primitive `number` keys are returned as-is.
+ *
+ * @param data - The source record to extract a value from.
+ * @param key - Key describing how to extract the value; see {@link getValueFromKey}.
+ * @param numberFormat - Describes the decimal and digit-group separators used in string values.
+ * @returns The extracted value as a number, or `undefined` if the value is `null`, `undefined`,
+ *   an empty string, or non-numeric.
+ */
 export const getNumber = (
 	data: SourceRecord,
-	key: ParseFunction | string | ConstantValue | PathExpression,
+	key: ParseFunction | string | number | ConstantValue | PathExpression,
 	numberFormat: DecimalDigitGroup,
 ): number | undefined => {
 	let value = getValueFromKey(data, key) as number | null | string;
@@ -134,9 +184,16 @@ export const getNumber = (
 	return Number.isNaN(value as number) ? undefined : (Number(value) as number);
 };
 
+/**
+ * Extracts a value from a source record and coerces it to a boolean.
+ *
+ * @param data - The source record to extract a value from.
+ * @param key - Key describing how to extract the value; see {@link getValueFromKey}.
+ * @returns The extracted value coerced to a boolean.
+ */
 export const getBoolean = (
 	data: SourceRecord,
-	key: ParseFunction | string | ConstantValue | PathExpression,
+	key: ParseFunction | string | boolean | ConstantValue | PathExpression,
 ): boolean => {
 	const value = getValueFromKey(data, key);
 	if (typeof value === "string") {
@@ -147,6 +204,14 @@ export const getBoolean = (
 	return Boolean(value);
 };
 
+/**
+ * Extracts a value from a source record and returns it as an array.
+ *
+ * @param data - The source record to extract a value from.
+ * @param key - Key describing how to extract the value; see {@link getValueFromKey}.
+ * @returns The extracted value as an array of strings or numbers, or `undefined`
+ *   if the value is `null`, `undefined`, or an empty string.
+ */
 export const getArray = (
 	data: SourceRecord,
 	key: ParseFunction | string | ConstantValue | PathExpression,
@@ -161,6 +226,7 @@ export const getArray = (
 	if (!Array.isArray(value)) return [value];
 	return value;
 };
+
 /**
  * Maps human-readable separator names to their corresponding Unicode
  * characters. Used to resolve decimal and digit-group separator keys in
@@ -240,4 +306,42 @@ export function normalizeNumericString(
 	}
 
 	return v;
+}
+
+/**
+ * Creates a JMESPath {@link PathExpression} for extracting values from source records.
+ *
+ * @param value - A valid JMESPath query string.
+ * @returns A `PathExpression`.
+ *
+ * @see {@link https://jmespath.site} for JMESPath syntax reference.
+ *
+ * @example
+ * jmespath('device.location.latitude')
+ */
+export function jmespath(value: string): PathExpression {
+	return {
+		type: "jmespath",
+		value,
+	};
+}
+
+/**
+ * Helper function to create a {@link ConstantValue}.
+ *
+ * @param value - The constant string, number, or boolean to return.
+ * @returns A `ConstantValue` wrapper for use anywhere a key expression is accepted.
+ *
+ * @example
+ * constant(3600)
+ * constant(true)
+ * constant('metric')
+ */
+export function constant<T extends string | boolean | number>(
+	value: T,
+): ConstantValue<T> {
+	return {
+		type: "constant",
+		value,
+	};
 }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,10 +1,17 @@
 import { type JSONValue, search } from "@jmespath-community/jmespath";
 import debug from "debug";
-import type { ParseFunction } from "../types/client";
+import {
+	type ConstantValue,
+	isConstantValue,
+	isStructuredKey,
+	type ParseFunction,
+	type StructuredKey,
+} from "../types/client";
 import type { SourceRecord } from "../types/data";
 import {
 	type DecimalDigitGroup,
 	isPathExpression,
+	PATH_EXPRESSION_TYPES,
 	type PathExpression,
 } from "../types/metric";
 
@@ -23,23 +30,32 @@ export const stripNulls = <T extends object>(
 
 export const getValueFromKey = (
 	data: SourceRecord,
-	key: ParseFunction | string | PathExpression,
+	key: ParseFunction | string | ConstantValue | PathExpression,
 ) => {
-	let value = null;
-	if (isPathExpression(key)) {
-		if (key.type === "jmespath") {
-			log(`getting value from key using ${key.expression}`);
-			value = search(data as unknown as JSONValue, key.expression);
-		} else {
-			throw TypeError(
-				`TypeError: unsupported path expression type, supported syntaxes include: jmespath`,
-			);
+	if (isStructuredKey(key)) {
+		if (isPathExpression(key)) {
+			if (key.type === "jmespath") {
+				log(`getting value from key using ${key.value}`);
+				const value = search(data as unknown as JSONValue, key.value);
+				return value;
+			} else {
+				throw TypeError(
+					`TypeError: unsupported path expression type, supported syntaxes include: jmespath`,
+				);
+			}
 		}
+		if (isConstantValue(key)) {
+			return key.value;
+		}
+		throw new TypeError(
+			`Unsupported key type '${(key as StructuredKey).type}', supported types are: ${PATH_EXPRESSION_TYPES.join(", ")}, constant`,
+		);
 	}
 	if (typeof key === "function") {
 		log(`getting value from key using 'function'`);
 		try {
-			value = key(data);
+			const value = key(data);
+			return value;
 		} catch (error: unknown) {
 			if (error instanceof TypeError) {
 				throw new Error(
@@ -49,9 +65,10 @@ export const getValueFromKey = (
 		}
 	} else if (typeof key === "string") {
 		log(`getting value from key using '${key}'`);
-		value = data ? data[key] : key;
+		const value = data ? data[key] : key;
+		return value;
 	}
-	return value;
+	return null;
 };
 
 export const cleanKey = (value: unknown): string | undefined => {
@@ -101,7 +118,7 @@ export function formatValueForLog(value: unknown): string {
 
 export const getString = (
 	data: SourceRecord,
-	key: ParseFunction | string | PathExpression,
+	key: ParseFunction | string | ConstantValue | PathExpression,
 ): string | undefined => {
 	const value = getValueFromKey(data, key);
 	if (value == null) return undefined;
@@ -110,7 +127,7 @@ export const getString = (
 
 export const getNumber = (
 	data: SourceRecord,
-	key: ParseFunction | string | PathExpression,
+	key: ParseFunction | string | ConstantValue | PathExpression,
 	numberFormat: DecimalDigitGroup,
 ): number | undefined => {
 	let value = getValueFromKey(data, key) as number | null | string;
@@ -123,7 +140,7 @@ export const getNumber = (
 
 export const getBoolean = (
 	data: SourceRecord,
-	key: ParseFunction | string | PathExpression,
+	key: ParseFunction | string | ConstantValue | PathExpression,
 ): boolean => {
 	const value = getValueFromKey(data, key);
 	if (typeof value === "string") {
@@ -136,7 +153,7 @@ export const getBoolean = (
 
 export const getArray = (
 	data: SourceRecord,
-	key: ParseFunction | string | PathExpression,
+	key: ParseFunction | string | ConstantValue | PathExpression,
 ): (string | number)[] | undefined => {
 	const value = getValueFromKey(data, key) as
 		| number

--- a/src/node/client.spec.ts
+++ b/src/node/client.spec.ts
@@ -14,6 +14,7 @@ Settings.now = () => expectedNow.toMillis();
 
 import debug from "debug";
 import { Resource } from "../core/resource.ts";
+import { constant } from "../core/utils.ts";
 
 debug.enable("openaq*");
 
@@ -255,15 +256,15 @@ describe("Client with data in wide format", () => {
 		resource = new Resource({ url: "https://blah.org/wide" });
 		provider = "testing";
 		// mapping data
-		xGeometryKey = "longitude";
-		averagingIntervalKey = "averaging";
-		sensorStatusKey = () => "asdf";
-		yGeometryKey = "latitude";
-		locationIdKey = "station";
-		locationLabelKey = "site_name";
-		geometryProjectionKey = () => "WGS84";
-		ownerKey = () => "test_owner";
-		isMobileKey = () => false;
+		xGeometry = "longitude";
+		averagingInterval = "averaging";
+		sensorStatus = () => "asdf";
+		yGeometry = "latitude";
+		locationId = "station";
+		locationLabel = "site_name";
+		geometryProjection = () => "WGS84";
+		owner = () => "test_owner";
+		isMobile = () => false;
 		parameters = [
 			// provider_parameter_name: { parameter: 'openaq_name', unit: 'provider_units', key: "provider field" }
 			{ parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
@@ -307,15 +308,15 @@ describe("Client with data split between two different resources", () => {
 		};
 		provider = "testing";
 		// mapping data
-		xGeometryKey = "longitude";
-		averagingIntervalKey = "averaging";
-		sensorStatusKey = () => "asdf";
-		yGeometryKey = "latitude";
-		locationIdKey = "station";
-		locationLabelKey = "site_name";
-		geometryProjectionKey = () => "WGS84";
-		ownerKey = () => "test_owner";
-		isMobileKey = () => false;
+		xGeometry = "longitude";
+		averagingInterval = "averaging";
+		sensorStatus = () => "asdf";
+		yGeometry = "latitude";
+		locationId = "station";
+		locationLabel = "site_name";
+		geometryProjection = () => "WGS84";
+		owner = () => "test_owner";
+		isMobile = () => false;
 		parameters = [
 			{ parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
 			{ parameter: "temperature", unit: "f", key: "tempf" },
@@ -343,15 +344,15 @@ describe("Client with an indexed resource that returns a ResourceData object", (
 
 		provider = "testing";
 		// mapping data
-		xGeometryKey = "longitude";
-		averagingIntervalKey = "averaging";
-		sensorStatusKey = () => "asdf";
-		yGeometryKey = "latitude";
-		locationIdKey = "station";
-		locationLabelKey = "site_name";
-		geometryProjectionKey = () => "WGS84";
-		ownerKey = () => "test_owner";
-		isMobileKey = () => false;
+		xGeometry = "longitude";
+		averagingInterval = "averaging";
+		sensorStatus = () => "asdf";
+		yGeometry = "latitude";
+		locationId = "station";
+		locationLabel = "site_name";
+		geometryProjection = () => "WGS84";
+		owner = () => "test_owner";
+		isMobile = () => false;
 		parameters = [
 			{ parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
 			{ parameter: "temperature", unit: "f", key: "tempf" },
@@ -372,15 +373,15 @@ describe("Client with data in long format", () => {
 		provider = "testing";
 		// mapping data
 		longFormat = true;
-		xGeometryKey = "longitude";
-		yGeometryKey = "latitude";
-		averagingIntervalKey = "averaging";
-		sensorStatusKey = () => "asdf";
-		locationIdKey = "station";
-		locationLabelKey = "site_name";
-		geometryProjectionKey = () => "WGS84";
-		ownerKey = () => "test_owner";
-		isMobileKey = () => false;
+		xGeometry = "longitude";
+		yGeometry = "latitude";
+		averagingInterval = "averaging";
+		sensorStatus = () => "asdf";
+		locationId = "station";
+		locationLabel = "site_name";
+		geometryProjection = () => "WGS84";
+		owner = () => "test_owner";
+		isMobile = () => false;
 		parameters = [
 			{ parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
 			{ parameter: "temperature", unit: "f", key: "tempf" },
@@ -400,15 +401,15 @@ describe("Provider that passes sensor data", () => {
 		provider = "testing";
 		// mapping data
 		longFormat = true;
-		xGeometryKey = "longitude";
-		yGeometryKey = "latitude";
-		averagingIntervalKey = "averaging";
-		sensorStatusKey = () => "asdf";
-		locationIdKey = "station";
-		locationLabelKey = "site_name";
-		geometryProjectionKey = () => "WGS84";
-		ownerKey = () => "test_owner";
-		isMobileKey = () => false;
+		xGeometry = "longitude";
+		yGeometry = "latitude";
+		averagingInterval = "averaging";
+		sensorStatus = () => "asdf";
+		locationId = "station";
+		locationLabel = "site_name";
+		geometryProjection = () => "WGS84";
+		owner = () => "test_owner";
+		isMobile = () => false;
 		parameters = [
 			{ parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
 			{ parameter: "temperature", unit: "f", key: "tempf" },
@@ -435,15 +436,16 @@ describe("Dynamic adapter that gets mapping from initial config", () => {
 
 	test("outputs correct format", async () => {
 		const cln = new JsonClient({
-			xGeometryKey: "longitude",
-			yGeometryKey: "latitude",
-			averagingIntervalKey: "averaging",
-			sensorStatusKey: () => "asdf",
-			locationIdKey: "station",
-			locationLabelKey: "site_name",
-			geometryProjectionKey: () => "WGS84",
-			ownerKey: () => "test_owner",
-			isMobileKey: () => false,
+			xGeometry: "longitude",
+			yGeometry: "latitude",
+			timeEnding: true,
+			averagingInterval: "averaging",
+			sensorStatus: () => "asdf",
+			locationId: "station",
+			locationLabel: "site_name",
+			geometryProjection: () => "WGS84",
+			owner: () => "test_owner",
+			isMobile: () => false,
 		});
 		const data = await cln.load();
 		expect(data).toStrictEqual(expectedOutput);
@@ -466,15 +468,16 @@ describe("Dynamic adapter that gets mapping from delayed configure", () => {
 				{ parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
 				{ parameter: "temperature", unit: "f", key: "tempf" },
 			],
-			xGeometryKey: "longitude",
-			yGeometryKey: "latitude",
-			averagingIntervalKey: "averaging",
-			sensorStatusKey: () => "asdf",
-			locationIdKey: "station",
-			locationLabelKey: "site_name",
-			geometryProjectionKey: () => "WGS84",
-			ownerKey: () => "test_owner",
-			isMobileKey: () => false,
+			timeEnding: true,
+			xGeometry: "longitude",
+			yGeometry: "latitude",
+			averagingInterval: "averaging",
+			sensorStatus: () => "asdf",
+			locationId: "station",
+			locationLabel: "site_name",
+			geometryProjection: () => "WGS84",
+			owner: () => "test_owner",
+			isMobile: () => false,
 		});
 
 		const data = await cln.load();
@@ -600,15 +603,15 @@ describe("Client with measurement errors", () => {
 		provider = "testing";
 		strict = false;
 		longFormat = true;
-		xGeometryKey = "longitude";
-		averagingIntervalKey = "averaging";
-		sensorStatusKey = () => "asdf";
-		yGeometryKey = "latitude";
-		locationIdKey = "station";
-		locationLabelKey = "site_name";
-		geometryProjectionKey = () => "WGS84";
-		ownerKey = () => "test_owner";
-		isMobileKey = () => false;
+		xGeometry = "longitude";
+		averagingInterval = "averaging";
+		sensorStatus = () => "asdf";
+		yGeometry = "latitude";
+		locationId = "station";
+		locationLabel = "site_name";
+		geometryProjection = () => "WGS84";
+		owner = () => "test_owner";
+		isMobile = () => false;
 		parameters = [
 			{ parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
 			{ parameter: "temperature", unit: "f", key: "tempf" },
@@ -738,15 +741,15 @@ describe("Client with digit group and decimal delimiter setting", () => {
 		provider = "testing";
 		strict = false;
 		longFormat = true;
-		xGeometryKey = "longitude";
-		averagingIntervalKey = "averaging";
-		sensorStatusKey = () => "asdf";
-		yGeometryKey = "latitude";
-		locationIdKey = "station";
-		locationLabelKey = "site_name";
-		geometryProjectionKey = () => "WGS84";
-		ownerKey = () => "test_owner";
-		isMobileKey = () => false;
+		xGeometry = "longitude";
+		averagingInterval = "averaging";
+		sensorStatus = () => "asdf";
+		yGeometry = "latitude";
+		locationId = "station";
+		locationLabel = "site_name";
+		geometryProjection = () => "WGS84";
+		owner = () => "test_owner";
+		isMobile = () => false;
 		numberFormat = {decimal: "comma", digitGroup: "dot"} as const;
 		parameters = [
 			{ parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
@@ -788,15 +791,15 @@ describe("Client with jmespath responsePath nested data key", () => {
             })
 		}
         provider = "testing";
-        xGeometryKey = "longitude";
-        averagingIntervalKey = "averaging";
-        sensorStatusKey = () => "asdf";
-        yGeometryKey = "latitude";
-        locationIdKey = "station";
-        locationLabelKey = "site_name";
-        geometryProjectionKey = () => "WGS84";
-        ownerKey = () => "test_owner";
-        isMobileKey = () => false;
+        xGeometry = "longitude";
+        averagingInterval = "averaging";
+        sensorStatus = () => "asdf";
+        yGeometry = "latitude";
+        locationId = "station";
+        locationLabel = "site_name";
+        geometryProjection = () => "WGS84";
+        owner = () => "test_owner";
+        isMobile = () => false;
         parameters = [
             { parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
             { parameter: "temperature", unit: "f", key: "tempf" },
@@ -818,15 +821,15 @@ describe("Client with jmespath responsePath on single resource", () => {
             responsePath: { type: "jmespath", value: "data" },
         });
         provider = "testing";
-        xGeometryKey = "longitude";
-        averagingIntervalKey = () => 3600;
-        sensorStatusKey = () => "asdf";
-        yGeometryKey = "latitude";
-        locationIdKey = "station";
-        locationLabelKey = "site_name";
-        geometryProjectionKey = () => "WGS84";
-        ownerKey = () => "test_owner";
-        isMobileKey = () => false;
+        xGeometry = "longitude";
+        averagingInterval = 3600;
+        sensorStatus = constant("asdf");
+        yGeometry = "latitude";
+        locationId = "station";
+        locationLabel = "site_name";
+        geometryProjection = constant("WGS84");
+        owner = constant("test_owner");
+        isMobile = false;
         parameters = [
             { parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
             { parameter: "temperature", unit: "f", key: "tempf" },
@@ -849,15 +852,15 @@ describe("Client with string responsePath on single resource", () => {
             responsePath: "data",
         });
         provider = "testing";
-        xGeometryKey = "longitude";
-        averagingIntervalKey = () => 3600;
-        sensorStatusKey = () => "asdf";
-        yGeometryKey = "latitude";
-        locationIdKey = "station";
-        locationLabelKey = "site_name";
-        geometryProjectionKey = () => "WGS84";
-        ownerKey = () => "test_owner";
-        isMobileKey = () => false;
+        xGeometry = "longitude";
+        averagingInterval = () => 3600;
+        sensorStatus = () => "asdf";
+        yGeometry = "latitude";
+        locationId = "station";
+        locationLabel = "site_name";
+        geometryProjection = () => "WGS84";
+        owner = () => "test_owner";
+        isMobile = () => false;
         parameters = [
             { parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
             { parameter: "temperature", unit: "f", key: "tempf" },
@@ -878,15 +881,15 @@ describe("Client with timeEnding=false normalizes timestamps to time-ending", ()
 		provider = "testing";
 		longFormat = true;
 		timeEnding = false;
-		xGeometryKey = "longitude";
-		yGeometryKey = "latitude";
-		averagingIntervalKey = () => 3600
-		sensorStatusKey = () => "asdf";
-		locationIdKey = "station";
-		locationLabelKey = "site_name";
-		geometryProjectionKey = () => "WGS84";
-		ownerKey = () => "test_owner";
-		isMobileKey = () => false;
+		xGeometry = "longitude";
+		yGeometry = "latitude";
+		averagingInterval = () => 3600
+		sensorStatus = () => "asdf";
+		locationId = "station";
+		locationLabel = "site_name";
+		geometryProjection = () => "WGS84";
+		owner = () => "test_owner";
+		isMobile = () => false;
 		parameters = [
 			{ parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
 			{ parameter: "temperature", unit: "f", key: "tempf" },

--- a/src/node/client.spec.ts
+++ b/src/node/client.spec.ts
@@ -779,12 +779,12 @@ describe("Client with jmespath responsePath nested data key", () => {
         resource = { measurements: new Resource({
                 url: "https://blah.org/test-provider/wrapped",
                 output: "object",
-                responsePath: { type: "jmespath", expression: "data.measurements" }
+                responsePath: { type: "jmespath", value: "data.measurements" }
             }),
 			locations:  new Resource({
                 url: "https://blah.org/test-provider/wrapped",
                 output: "object",
-                responsePath: { type: "jmespath", expression: "data.locations" }
+                responsePath: { type: "jmespath", value: "data.locations" }
             })
 		}
         provider = "testing";
@@ -815,7 +815,7 @@ describe("Client with jmespath responsePath on single resource", () => {
         resource = new Resource({
             url: "https://blah.org/test-provider/wrapped-wide",
 			output: "object",
-            responsePath: { type: "jmespath", expression: "data" },
+            responsePath: { type: "jmespath", value: "data" },
         });
         provider = "testing";
         xGeometryKey = "longitude";

--- a/src/types/client.spec.ts
+++ b/src/types/client.spec.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "vitest";
+import { isConstantValue, isIndexedParser, isIndexedReader, isStructuredKey } from "./client";
+
+describe('isStructuredKey', () => {
+  test('returns true for a valid StructuredKey', () => {
+    expect(isStructuredKey({ type: 'jmespath', value: 'foo' })).toBe(true);
+  });
+
+  test('returns false for null', () => {
+    expect(isStructuredKey(null)).toBe(false);
+  });
+
+  test('returns false for a string', () => {
+    expect(isStructuredKey('string')).toBe(false);
+  });
+
+  test('returns false when type is missing', () => {
+    expect(isStructuredKey({ value: 'foo' })).toBe(false);
+  });
+
+  test('returns false when value is missing', () => {
+    expect(isStructuredKey({ type: 'jmespath' })).toBe(false);
+  });
+});
+
+describe('isConstantValue', () => {
+  test('returns true for a ConstantValue with a string value', () => {
+    expect(isConstantValue({ type: 'constant', value: 'foo' })).toBe(true);
+  });
+
+  test('returns true for a ConstantValue with a number value', () => {
+    expect(isConstantValue({ type: 'constant', value: 42 })).toBe(true);
+  });
+
+  test('returns false for null', () => {
+    expect(isConstantValue(null)).toBe(false);
+  });
+
+  test('returns false for a string', () => {
+    expect(isConstantValue('constant')).toBe(false);
+  });
+
+  test('returns false when type is missing', () => {
+    expect(isConstantValue({ value: 'foo' })).toBe(false);
+  });
+
+  test('returns false when value is missing', () => {
+    expect(isConstantValue({ type: 'constant' })).toBe(false);
+  });
+
+  test('returns false when type is a PathExpression', () => {
+    expect(isConstantValue({ type: 'jmespath', value: 'foo' })).toBe(false);
+  });
+});
+
+describe('isIndexedReader', () => {
+  test('returns true for a valid IndexedReader', () => {
+    expect(isIndexedReader({ measurements: 'api' })).toBe(true);
+  });
+
+  test('returns true for a valid IndexedReader with multiple keys', () => {
+    expect(isIndexedReader({ measurements: 'api', locations: 'api' })).toBe(true);
+  });
+
+  test('returns false for null', () => {
+    expect(isIndexedReader(null)).toBe(false);
+  });
+
+  test('returns false for a primitive', () => {
+    expect(isIndexedReader('reader')).toBe(false);
+  });
+
+  test('returns false for an array', () => {
+    expect(isIndexedReader([{ measurements: 'api' }])).toBe(false);
+  });
+
+  test('returns false for an empty object', () => {
+    expect(isIndexedReader({})).toBe(false);
+  });
+});
+
+describe('isIndexedParser', () => {
+  test('returns true for a valid IndexedParser', () => {
+    expect(isIndexedParser({ measurements: 'xml' })).toBe(true);
+  });
+
+  test('returns true for a valid IndexedParser with multiple keys', () => {
+    expect(isIndexedParser({ measurements: 'xml', locations: 'json' })).toBe(true);
+  });
+
+  test('returns false for null', () => {
+    expect(isIndexedParser(null)).toBe(false);
+  });
+
+  test('returns false for a primitive', () => {
+    expect(isIndexedParser('parser')).toBe(false);
+  });
+
+  test('returns false for an array', () => {
+    expect(isIndexedParser([{ measurements: 'xml' }])).toBe(false);
+  });
+
+  test('returns false for an empty object', () => {
+    expect(isIndexedParser({})).toBe(false);
+  });
+});

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -101,11 +101,21 @@ export interface LogEntry {
 	err?: Error;
 }
 
+/**
+ * An shared interface for keyed values.
+ */
 export interface StructuredKey {
 	type: string;
 	value: unknown;
 }
 
+/**
+ * Type guard to check if a value is a {@link StructuredKey}.
+ *
+ * @param value - The value to check
+ * @returns `true` if the value is a valid StructuredKey, otherwise `false`
+ *
+ */
 export function isStructuredKey(value: unknown): value is StructuredKey {
 	return (
 		typeof value === "object" &&
@@ -115,11 +125,29 @@ export function isStructuredKey(value: unknown): value is StructuredKey {
 	);
 }
 
+/**
+ * An interface for defining constant values.
+ *
+ * @example
+ * ```ts
+ * const value: ConstantValue = {
+ *   type: 'constant',
+ *   value: 3600
+ * }
+ * ```
+ */
 export interface ConstantValue extends StructuredKey {
 	type: "constant";
 	value: string | number;
 }
 
+/**
+ * Type guard to check if a value is a {@link ConstantValue}.
+ *
+ * @param value - The value to check
+ * @returns `true` if the value is a valid ConstantValue, otherwise `false`
+ *
+ */
 export function isConstantValue(value: unknown): value is ConstantValue {
 	return (
 		typeof value === "object" &&

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -8,6 +8,7 @@ import type { MeasurementJSON } from "./measurement";
 import type {
 	ClientParameters,
 	DecimalDigitGroup,
+	SupportedExpressionLanguages,
 	ValueFlagMap,
 } from "./metric";
 import type { IndexedParser, Parser } from "./parsers";
@@ -66,8 +67,8 @@ export interface TransformData {
 }
 
 export interface ClientInfoKey {
-	type: "function" | "field" | "jmespath";
-	value: string | undefined;
+	type: "function" | "field" | "constant" | SupportedExpressionLanguages;
+	value: string | number | undefined;
 }
 
 export interface ClientInfoParameter {
@@ -98,6 +99,35 @@ export interface ClientInfo {
 export interface LogEntry {
 	message: string;
 	err?: Error;
+}
+
+export interface StructuredKey {
+	type: string;
+	value: unknown;
+}
+
+export function isStructuredKey(value: unknown): value is StructuredKey {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"type" in value &&
+		"value" in value
+	);
+}
+
+export interface ConstantValue extends StructuredKey {
+	type: "constant";
+	value: string | number;
+}
+
+export function isConstantValue(value: unknown): value is ConstantValue {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"type" in value &&
+		"value" in value &&
+		(value as ConstantValue).type === "constant"
+	);
 }
 
 export type ParseFunction = (

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -16,18 +16,18 @@ import type { IndexedReaderOptions, Reader, ReaderOptions } from "./readers";
 import type { ResourceKeys } from "./resource";
 
 interface Meta {
-	locationIdKey: string;
-	locationLabelKey: string;
-	parameterKey: string;
-	valueKey: string;
+	locationId: string;
+	locationLabel: string;
+	parameter: string;
+	value: string;
 	projection: string;
-	latitudeKey: string;
-	longitudeKey: string;
-	manufacturerKey: string;
-	modelKey: string;
-	ownerKey: string;
-	licenseKey: string;
-	timestampKey: string;
+	latitude: string;
+	longitude: string;
+	manufacturer: string;
+	model: string;
+	owner: string;
+	license: string;
+	timestamp: string;
 	datetimeFormat: string;
 	timezone: string;
 }
@@ -68,7 +68,7 @@ export interface TransformData {
 
 export interface ClientInfoKey {
 	type: "function" | "field" | "constant" | SupportedExpressionLanguages;
-	value: string | number | undefined;
+	value: string | number | boolean | undefined;
 }
 
 export interface ClientInfoParameter {
@@ -80,15 +80,15 @@ export interface ClientInfo {
 	timezone: string | undefined;
 	provider: string;
 	isLongFormat: boolean;
-	datetimeKey: ClientInfoKey;
+	datetime: ClientInfoKey;
 	datetimeFormat: string;
-	geometryProjectionKey: ClientInfoKey;
-	xGeometryKey: ClientInfoKey;
-	yGeometryKey: ClientInfoKey;
-	manufacturerKey: ClientInfoKey;
-	modelKey: ClientInfoKey;
-	ownerKey: ClientInfoKey;
-	licenseKey: ClientInfoKey;
+	geometryProjection: ClientInfoKey;
+	xGeometry: ClientInfoKey;
+	yGeometry: ClientInfoKey;
+	manufacturer: ClientInfoKey;
+	model: ClientInfoKey;
+	owner: ClientInfoKey;
+	license: ClientInfoKey;
 	ingestMatchingMethod: string;
 	isMobile: ClientInfoKey;
 	loggingInterval: ClientInfoKey;
@@ -136,9 +136,10 @@ export function isStructuredKey(value: unknown): value is StructuredKey {
  * }
  * ```
  */
-export interface ConstantValue extends StructuredKey {
+export interface ConstantValue<T = string | boolean | number>
+	extends StructuredKey {
 	type: "constant";
-	value: string | number;
+	value: T;
 }
 
 /**
@@ -192,24 +193,24 @@ export interface ClientConfiguration {
 	timeEnding: boolean;
 	secrets?: object;
 
-	locationIdKey?: string | ParseFunction;
-	locationLabelKey?: string | ParseFunction;
-	parameterNameKey?: string | ParseFunction;
-	parameterValueKey?: string | ParseFunction;
-	flagsKey?: string | ParseFunction;
+	locationId?: string | ParseFunction;
+	locationLabel?: string | ParseFunction;
+	parameterName?: string | ParseFunction;
+	parameterValue?: string | ParseFunction;
+	flags?: string | ParseFunction;
 	numberFormat?: DecimalDigitGroup;
-	xGeometryKey?: string | ParseFunction;
-	yGeometryKey?: string | ParseFunction;
-	geometryProjectionKey?: string | ParseFunction;
-	manufacturerKey?: string | ParseFunction;
-	modelKey?: string | ParseFunction;
-	ownerKey?: string | ParseFunction;
-	datetimeKey?: string | ParseFunction;
-	licenseKey?: string | ParseFunction;
-	isMobileKey?: string | ParseFunction;
-	loggingIntervalKey?: string | ParseFunction;
-	averagingIntervalKey?: string | ParseFunction;
-	sensorStatusKey?: string | ParseFunction;
+	xGeometry?: string | ParseFunction;
+	yGeometry?: string | ParseFunction;
+	geometryProjection?: string | ParseFunction;
+	manufacturer?: string | ParseFunction;
+	model?: string | ParseFunction;
+	owner?: string | ParseFunction;
+	datetime?: string | ParseFunction;
+	license?: string | ParseFunction;
+	isMobile?: string | ParseFunction;
+	loggingInterval?: string | ParseFunction;
+	averagingInterval?: string | ParseFunction;
+	sensorStatus?: string | ParseFunction;
 	providerFlags?: ValueFlagMap;
 
 	datasources?: object;

--- a/src/types/datetime.spec.ts
+++ b/src/types/datetime.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "vitest";
+
+import {isTimeOffset} from './datetime';
+
+describe('isTimeOffset', () => {
+  test('returns true for a TimeOffset with minutes', () => {
+    expect(isTimeOffset({ minutes: 42 })).toBe(true);
+  });
+
+  test('returns true for a TimeOffset with days', () => {
+    expect(isTimeOffset({ days: 2 })).toBe(true);
+  });
+
+  test('returns true for a TimeOffset with hours', () => {
+    expect(isTimeOffset({ hours: 1 })).toBe(true);
+  });
+
+  test('returns true for a TimeOffset with multiple properties', () => {
+    expect(isTimeOffset({ days: 2, hours: 3, minutes: 42 })).toBe(true);
+  });
+
+  test('returns true for a TimeOffset with zero values', () => {
+    expect(isTimeOffset({ hours: 0, minutes: 0 })).toBe(true);
+  });
+
+  test('returns false for null', () => {
+    expect(isTimeOffset(null)).toBe(false);
+  });
+
+  test('returns false for a primitive', () => {
+    expect(isTimeOffset(30)).toBe(false);
+  });
+
+  test('returns false for an array', () => {
+    expect(isTimeOffset([{ minutes: 30 }])).toBe(false);
+  });
+
+  test('returns false for an empty object', () => {
+    expect(isTimeOffset({})).toBe(false);
+  });
+
+  test('returns false when no valid TimeOffset properties are present', () => {
+    expect(isTimeOffset({ seconds: 30 })).toBe(false);
+  });
+
+  test('returns false when minutes is a string', () => {
+    expect(isTimeOffset({ minutes: '30' })).toBe(false);
+  });
+
+  test('returns false when days is a string', () => {
+    expect(isTimeOffset({ days: '2' })).toBe(false);
+  });
+
+  test('returns false when hours is a string', () => {
+    expect(isTimeOffset({ hours: '1' })).toBe(false);
+  });
+});
+

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,3 @@
-export type { PathExpression } from "./metric.ts";
+export type { ClientConfiguration, ConstantValue } from "./client.ts";
+export type { DecimalDigitGroup, PathExpression } from "./metric.ts";
 export type { ResourceKeys } from "./resource.ts";

--- a/src/types/metric.spec.ts
+++ b/src/types/metric.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "vitest";
+import { isPathExpression } from "./metric";
+
+describe('isPathExpression', () => {
+  test('returns true for a valid jmespath PathExpression', () => {
+    expect(isPathExpression({ type: 'jmespath', value: 'measurements.o3.value' })).toBe(true);
+  });
+
+  test('returns false for null', () => {
+    expect(isPathExpression(null)).toBe(false);
+  });
+
+  test('returns false for a string', () => {
+    expect(isPathExpression('jmespath')).toBe(false);
+  });
+
+  test('returns false when type is missing', () => {
+    expect(isPathExpression({ value: 'measurements.o3.value' })).toBe(false);
+  });
+
+  test('returns false when value is missing', () => {
+    expect(isPathExpression({ type: 'jmespath' })).toBe(false);
+  });
+
+  test('returns false when type is not a supported expression language', () => {
+    expect(isPathExpression({ type: 'xpath', value: '/measurements/o3/value' })).toBe(false);
+  });
+
+  test('returns false when value is not a string', () => {
+    expect(isPathExpression({ type: 'jmespath', value: 42 })).toBe(false);
+  });
+
+  test('returns false for a ConstantValue', () => {
+    expect(isPathExpression({ type: 'constant', value: 'foo' })).toBe(false);
+  });
+});

--- a/src/types/metric.ts
+++ b/src/types/metric.ts
@@ -1,4 +1,7 @@
 // based on common groups in Examples of Use table https://en.wikipedia.org/wiki/Decimal_separator#Other_numeral_systems
+
+import type { StructuredKey } from "./client";
+
 /**
  * Describes the decimal and digit-group separator conventions for a numeric
  * locale format.
@@ -211,17 +214,21 @@ export type SupportedExpressionLanguages = "jmespath";
  * // Extract a nested property using JMESPath
  * const expr: PathExpression = {
  *   type: 'jmespath',
- *   expression: 'measurements.o3.value'
+ *   value: 'measurements.o3.value'
  * }
  * ```
  */
-export interface PathExpression {
+export interface PathExpression extends StructuredKey {
 	/** The query language used to interpret the expression */
 	type: SupportedExpressionLanguages;
 
 	/** The query expression in the specified language syntax */
-	expression: string;
+	value: string;
 }
+
+export const PATH_EXPRESSION_TYPES: SupportedExpressionLanguages[] = [
+	"jmespath",
+];
 
 /**
  * Type guard to check if a value is a {@link PathExpression}.
@@ -235,9 +242,9 @@ export function isPathExpression(value: unknown): value is PathExpression {
 		typeof value === "object" &&
 		value !== null &&
 		"type" in value &&
-		"expression" in value &&
-		typeof (value as PathExpression).type === "string" &&
-		typeof (value as PathExpression).expression === "string"
+		"value" in value &&
+		PATH_EXPRESSION_TYPES.includes((value as PathExpression).type) &&
+		typeof (value as PathExpression).value === "string"
 	);
 }
 
@@ -262,7 +269,7 @@ export function isPathExpression(value: unknown): value is PathExpression {
  *   unit: 'ppm',
  *   key: {
  *     type: 'jmespath',
- *     expression: 'measurements.o3.value'
+ *     value: 'measurements.o3.value'
  *   }
  * }
  *


### PR DESCRIPTION
resolves #68 

Adds a new type for defining constant values with instantiating the client so that functions are not required:

```ts
const client = new Client({
    ...
    averagingIntervalKey = {
        type: 'constant',
        value: 3600
    }
    ...
})
```


This also changes the signature for `ParseExpression` to normalize the shape so that `ConstantValue` and ParseExpression both follow the form:
```ts
{
    type:  ...,
    value: ...
}
```