### PR TITLE
adds context option to resource

### DIFF
--- a/src/core/readers.spec.ts
+++ b/src/core/readers.spec.ts
@@ -571,3 +571,82 @@ test("mergeObjects works", async () => {
 
 	expect(mergeObjects(input)).toEqual(expected);
 });
+
+test("context is merged onto each row of an array response", async () => {
+	const resource = new Resource({
+		url: "https://api.test.com/stations",
+		context: { source: "test-provider" },
+	});
+
+	const result = await apiReader(
+		{ resource },
+		async (content: any) => content,
+		{},
+	);
+
+	expect(result).toEqual(
+		sampleData.map((row) => ({ source: "test-provider", ...row })),
+	);
+});
+
+test("context is merged onto an object response", async () => {
+	const resource = new Resource({
+		url: "https://api.test.com/stations/:station",
+		parameters: [{ station: "A" }],
+		context: (params) => ({ station: params.station }),
+	});
+
+	const result = await apiReader(
+		{ resource },
+		async (content: any) => content,
+		{},
+	);
+
+	expect(result).toEqual({ station: "A", ...objectData.stations[0] });
+});
+
+test("context is merged per-url when derived from parameters", async () => {
+	const resource = new Resource({
+		url: "https://api.test.com/stations/:station",
+		parameters: [{ station: "A" }, { station: "B" }],
+		context: (params) => ({ station: params.station }),
+	});
+
+	const result = await apiReader(
+		{ resource },
+		async (content: any) => content,
+		{},
+	);
+
+	expect(result).toEqual([
+		{ station: "A", ...objectData.stations[0] },
+		{ station: "B", ...objectData.stations[1] },
+	]);
+});
+
+test("real fields in the response take precedence over context", async () => {
+	const resource = new Resource({
+		url: "https://api.test.com/stations",
+		context: { id: "should-not-win" },
+	});
+
+	const result = await apiReader(
+		{ resource },
+		async (content: any) => content,
+		{},
+	);
+
+	expect(result).toEqual(sampleData);
+});
+
+test("no context means rows are unchanged", async () => {
+	const resource = new Resource({ url: "https://api.test.com/stations" });
+
+	const result = await apiReader(
+		{ resource },
+		async (content: any) => content,
+		{},
+	);
+
+	expect(result).toEqual(sampleData);
+});

--- a/src/core/readers.ts
+++ b/src/core/readers.ts
@@ -185,7 +185,7 @@ export async function apiReader(
 		const batch = urls.slice(i, i + concurrency);
 
 		await Promise.allSettled(
-			batch.map(async ({ url }) => {
+			batch.map(async ({ url, context }) => {
 				let raw: RawContent;
 				let readAsFormat: ReadAs | undefined;
 
@@ -283,6 +283,12 @@ export async function apiReader(
 						console.error(`Reader parse error at ${url}:`, parseError.message);
 					}
 					return;
+				}
+
+				if (context) {
+					parsed = Array.isArray(parsed)
+						? parsed.map((row) => ({ ...context, ...row }))
+						: { ...context, ...parsed };
 				}
 
 				if (resource.output && Array.isArray(parsed)) {

--- a/src/core/resource.spec.ts
+++ b/src/core/resource.spec.ts
@@ -289,3 +289,53 @@ test("Bearer auth header overwrite over Authorization header from readerOptions"
   });
   expect(resource.headers).toStrictEqual(new Headers({ Authorization: "Bearer newtoken" }));
 });
+
+test("resource with static context applies it to every url", () => {
+	const resource = new Resource({
+		url: "https://example.com/locations/:locationsId",
+		parameters: [{ locationsId: 42 }, { locationsId: 43 }],
+		context: { provider: "foo" },
+	});
+
+	expect(resource.urls).toStrictEqual([
+		{
+			url: "https://example.com/locations/42",
+			context: { provider: "foo" },
+		},
+		{
+			url: "https://example.com/locations/43",
+			context: { provider: "foo" },
+		},
+	]);
+});
+
+
+test("resource with context function derives context from each parameter set", () => {
+	const resource = new Resource({
+		url: "https://example.com/locations/:locationsId/measures",
+		parameters: [{ locationsId: 42 }, { locationsId: 43 }],
+		context: (params) => ({ locationId: params.locationsId }),
+	});
+
+	expect(resource.urls).toStrictEqual([
+		{
+			url: "https://example.com/locations/42/measures",
+			context: { locationId: 42 },
+		},
+		{
+			url: "https://example.com/locations/43/measures",
+			context: { locationId: 43 },
+		},
+	]);
+});
+
+test("resource without context does not add a context key", () => {
+	const resource = new Resource({
+		url: "https://example.com/locations/:locationsId",
+		parameters: [{ locationsId: 42 }],
+	});
+
+	expect(resource.urls).toStrictEqual([
+		{ url: "https://example.com/locations/42" },
+	]);
+});

--- a/src/core/resource.ts
+++ b/src/core/resource.ts
@@ -12,17 +12,13 @@ import {
 	type Auth,
 	type AuthValueFunction,
 	type Body,
+	type Context,
+	type ContextFunction,
 	isAuthValueFunction,
+	type Parameters,
+	type ParametersFunction,
+	type ResourceUrl,
 } from "../types/resource";
-
-type Parameters = Record<string, string | number | boolean>;
-
-type ParametersFunction = (data?: DataContext) => Parameters[];
-
-interface ResourceUrl {
-	url: string;
-	body?: Body;
-}
 
 /**
  * Defines how the reader should combine responses from multiple URLs.
@@ -58,6 +54,7 @@ type ResourceConfig =
 			parameters?: Parameters[] | ParametersFunction | PathExpression;
 			body?: Body;
 			responsePath?: PathExpression | string;
+			context?: Context | ContextFunction;
 			output?: ResourceOutput;
 			readAs?: ReadAs;
 			auth?: Auth;
@@ -71,6 +68,7 @@ type ResourceConfig =
 			parameters?: never;
 			body?: never;
 			responsePath?: PathExpression | string;
+			context?: Context | ContextFunction;
 			output?: ResourceOutput;
 			readAs?: ReadAs;
 			auth?: Auth;
@@ -108,6 +106,7 @@ export class Resource {
 	#parameters?: Parameters[] | ParametersFunction | PathExpression;
 	#body?: Body;
 	#data: DataContext;
+	#context?: Context | ContextFunction;
 	#responsePath?: PathExpression | string;
 	#output?: ResourceOutput;
 	#readAs?: ReadAs;
@@ -123,6 +122,7 @@ export class Resource {
 		this.#url = config.url;
 		this.#parameters = config.parameters;
 		this.#body = config.body;
+		this.#context = config.context;
 		this.#responsePath = config.responsePath;
 		this.#output = config.output;
 		this.#readAs = config.readAs;
@@ -401,15 +401,19 @@ export class Resource {
 					this.#body !== undefined
 						? Resource.buildBody(this.#body, params)
 						: undefined;
+				const context = this.resolveContext(params);
+
 				urls.push({
 					url,
 					...(body && { body: body }),
+					...(context && { context }),
 				});
 			}
 		} else {
 			urls.push({
 				url: this.#url,
 				...(this.#body && { body: this.#body }),
+				...(typeof this.#context === "object" && { context: this.#context }),
 			});
 		}
 		const { auth } = this;
@@ -425,6 +429,13 @@ export class Resource {
 		}
 
 		return urls;
+	}
+
+	private resolveContext(params: Parameters): Context | undefined {
+		if (!this.#context) return undefined;
+		return typeof this.#context === "function"
+			? this.#context(params)
+			: this.#context;
 	}
 
 	private resolveParameters(): Parameters[] {

--- a/src/types/resource.ts
+++ b/src/types/resource.ts
@@ -1,3 +1,5 @@
+import type { DataContext } from "./readers";
+
 export const RESOURCE_KEYS = [
 	"measurements",
 	"locations",
@@ -190,4 +192,21 @@ export type BearerAuth = {
 	};
 };
 
+export type Parameters = Record<string, string | number | boolean>;
+
+export type ParametersFunction = (data?: DataContext) => Parameters[];
+
+export interface ResourceUrl {
+	url: string;
+	body?: Body;
+	context?: Context;
+}
+
 export type Auth = BasicAuth | ApiKeyAuth | BearerAuth;
+
+export type Context = Record<string, string | number | boolean>;
+
+export type ContextFunction = (
+	parameters: Parameters,
+	data?: DataContext,
+) => Context;


### PR DESCRIPTION
Allows `parameters` or `data` to be accessed and attached to parser result within a resource. Most commonly used when a key is not explicitly included in a resource body but is implicitly available through a URL e.g. 

```ts

const client = new Client extend NodeClient({
      resource = {
        locations: new Resource({
          url: 'https://api.example.com/locations
        }),
        measurements: new Resource({
          url: 'https://api.example.com/locations/:locationId/measurements'
          parameters: (d) => {
            return d.locations.map((o) => {
              return {
                locationId: o.locationId
              }
            })
           context: (params) => { return { locationId: params.locationsId } }
          },
        })
      }
      ...
})
```

Where the payloads look like:


http://api.example.com/locations 

```json
[
  {
    locationId: 42,
    name: "foo"
  },
  {
    locationId: 43,
    name: "bar"
  },
  ...
]
```


http://api.example.com/locations/42/measurements

```json
[
  {
    parameter:'pm25',
    value: 32
  },
  {
    parameter:'pm25',
    name: 24
  },
  ...
]
```

Because the measurements payload does not include `locationsId` in the JSON transform cannot easily find and attach the measurements to the locations. `context` allows this value, derived from the URL parameters to get attached to the parser output.  resulting in something like:


```json
[
  {
    locationsId: 42,
    parameter:'pm25',
    value: 32
  },
  {
    locationsId: 42,
    parameter:'pm25',
    name: 24
  },
  ...
]
```