### PR TITLE
allow 0 value in wideformat

### DIFF
--- a/src/browser/client.spec.ts
+++ b/src/browser/client.spec.ts
@@ -33,6 +33,7 @@ class CustomClient extends Client {
 	isMobile = () => false;
 	parameters = [
 		{ parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
+		{ parameter: "pm10", unit: "ug/m3", key: "particulate_matter_10" },
 		{ parameter: "temperature", unit: "f", key: "tempf" },
 	];
 }

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -893,7 +893,10 @@ export abstract class Client<
 
 					// for wide format data we will not assume that null is a real measurement
 					// but for long format data we will assume it is valid
-					if (value !== undefined && (value || this.longFormat)) {
+					if (
+						value !== undefined &&
+						(this.longFormat || (value !== null && value !== ""))
+					) {
 						const metric = this.measurements.metricFromProviderKey(
 							metricName as string,
 						);

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -49,7 +49,6 @@ import {
 } from "./metric";
 import type { Resource } from "./resource";
 import { Sensor, Sensors } from "./sensor";
-
 import {
 	cleanKey,
 	formatValueForLog,
@@ -58,6 +57,7 @@ import {
 	getNumber,
 	getString,
 	getValueFromKey,
+	isBlank,
 	toUnixSeconds,
 } from "./utils";
 
@@ -893,10 +893,7 @@ export abstract class Client<
 
 					// for wide format data we will not assume that null is a real measurement
 					// but for long format data we will assume it is valid
-					if (
-						value !== undefined &&
-						(this.longFormat || (value !== null && value !== ""))
-					) {
+					if (value !== undefined && (this.longFormat || !isBlank(value))) {
 						const metric = this.measurements.metricFromProviderKey(
 							metricName as string,
 						);

--- a/src/core/metric.ts
+++ b/src/core/metric.ts
@@ -14,7 +14,7 @@ import {
 	UnsupportedParameterError,
 	UnsupportedUnitsError,
 } from "./errors";
-import { normalizeNumericString } from "./utils";
+import { isBlank, normalizeNumericString } from "./utils";
 
 const noConversion = (d: number | string) => +d;
 const ppbToPpm = (ppb: number | string) => +ppb / 1000;
@@ -442,13 +442,7 @@ export class Metric {
 		const range = this.parameter?.range;
 		let nv = null;
 
-		// first check if its some form of missing
-		if (
-			v === "" ||
-			v === null ||
-			v === undefined ||
-			(typeof v === "number" && Number.isNaN(v))
-		) {
+		if (isBlank(v) || (typeof v === "number" && Number.isNaN(v))) {
 			throw new MissingValueError(v);
 		}
 

--- a/src/core/utils.spec.ts
+++ b/src/core/utils.spec.ts
@@ -1,119 +1,118 @@
-import { describe, expect, test } from 'vitest';
-import type { PathExpression } from '../types/metric.ts';
-import { SourceRecord } from '../types/data.ts';
-
+import { describe, expect, test } from "vitest";
+import type { ConstantValue } from "../types/client.ts";
+import type { SourceRecord } from "../types/data.ts";
+import type { DecimalDigitGroup, PathExpression } from "../types/metric.ts";
+import { DatetimeError } from "./errors.ts";
 import {
-  cleanKey,
-  normalizeNumericString,
-  countDecimals,
-  getBoolean,
-  getNumber,
-  getString,
-  getArray,
-  getValueFromKey,
-  constant,
-  jmespath,
-  sanitizeKeyName,
-  toUnixSeconds,
-} from './utils.ts';
-import { DecimalDigitGroup } from '../types/metric.ts';
-import { ConstantValue } from '../types/client.ts';
-import { DatetimeError } from './errors.ts';
+	cleanKey,
+	constant,
+	countDecimals,
+	getArray,
+	getBoolean,
+	getNumber,
+	getString,
+	getValueFromKey,
+	isBlank,
+	jmespath,
+	normalizeNumericString,
+	sanitizeKeyName,
+	toUnixSeconds,
+} from "./utils.ts";
 
-test('cleanKey replaces only if value is truthy', () => {
-  expect(cleanKey('')).toBe('');
+test("cleanKey replaces only if value is truthy", () => {
+	expect(cleanKey("")).toBe("");
 });
 
-test('cleanKey removes leading and trailing whitespace', () => {
-  expect(cleanKey(' foobar ')).toBe('foobar');
+test("cleanKey removes leading and trailing whitespace", () => {
+	expect(cleanKey(" foobar ")).toBe("foobar");
 });
 
-test('cleanKey replaces internal spaces with underscore', () => {
-  expect(cleanKey('foo bar')).toBe('foo_bar');
+test("cleanKey replaces internal spaces with underscore", () => {
+	expect(cleanKey("foo bar")).toBe("foo_bar");
 });
 
-test('cleanKey removes non-word characters', () => {
-  expect(cleanKey('$foo#bar^')).toBe('foobar');
+test("cleanKey removes non-word characters", () => {
+	expect(cleanKey("$foo#bar^")).toBe("foobar");
 });
 
-test('cleanKey changes string to lowercase', () => {
-  expect(cleanKey('FOOBAR')).toBe('foobar');
+test("cleanKey changes string to lowercase", () => {
+	expect(cleanKey("FOOBAR")).toBe("foobar");
 });
 
-test('getValueFromKey returns undefined when key does not exist', () => {
-  expect(getValueFromKey({}, 'undefined_key')).toBe(undefined);
+test("getValueFromKey returns undefined when key does not exist", () => {
+	expect(getValueFromKey({}, "undefined_key")).toBe(undefined);
 });
 
-test('getValueFromKey returns value when key exists', () => {
-  expect(getValueFromKey({ pm25: null }, 'pm25')).toBe(null);
+test("getValueFromKey returns value when key exists", () => {
+	expect(getValueFromKey({ pm25: null }, "pm25")).toBe(null);
 });
 
-test('getValueFromKey returns value when using key function', () => {
-  expect(getValueFromKey({ pm25: 42 }, (o) => o.pm25)).toBe(42);
+test("getValueFromKey returns value when using key function", () => {
+	expect(getValueFromKey({ pm25: 42 }, (o) => o.pm25)).toBe(42);
 });
 
-test('getValueFromKey throws for unsafe optional property access', () => {
-  expect(getValueFromKey({ pm25: null }, (o) => o.foo)).toThrow(Error);
+test("getValueFromKey throws for unsafe optional property access", () => {
+	expect(getValueFromKey({ pm25: null }, (o) => o.foo)).toThrow(Error);
 });
 
-test('getValueFromKey returns value when using jmespath expression', () => {
-  const pathExpression = {
-    type: 'jmespath',
-    value: '$.measurements[0].pm25',
-  } satisfies PathExpression;
-  expect(
-    getValueFromKey({ measurements: [{ pm25: 42 }] }, pathExpression),
-  ).toBe(42);
+test("getValueFromKey returns value when using jmespath expression", () => {
+	const pathExpression = {
+		type: "jmespath",
+		value: "$.measurements[0].pm25",
+	} satisfies PathExpression;
+	expect(
+		getValueFromKey({ measurements: [{ pm25: 42 }] }, pathExpression),
+	).toBe(42);
 });
 
-test('getValueFromKey returns value when using constant value', () => {
-  const constantValue = {
-    type: 'constant',
-    value: 3600,
-  } satisfies ConstantValue;
-  expect(getValueFromKey({ measurements: [{ pm25: 42 }] }, constantValue)).toBe(
-    3600,
-  );
+test("getValueFromKey returns value when using constant value", () => {
+	const constantValue = {
+		type: "constant",
+		value: 3600,
+	} satisfies ConstantValue;
+	expect(getValueFromKey({ measurements: [{ pm25: 42 }] }, constantValue)).toBe(
+		3600,
+	);
 });
 
-test('getValueFromKey throws when unsupported expression type is passed', () => {
-  // @ts-expect-error Testing unsupported type value
-  const pathExpression = {
-    type: 'xpath',
-    value: '/measurements[0]/pm25',
-  } satisfies PathExpression;
-  // @ts-expect-error Testing unsupported type value
-  expect(() =>
-    getValueFromKey({ measurements: [{ pm25: 42 }] }, pathExpression),
-  ).toThrow(TypeError);
+test("getValueFromKey throws when unsupported expression type is passed", () => {
+	// @ts-expect-error Testing unsupported type value
+	const pathExpression = {
+		type: "xpath",
+		value: "/measurements[0]/pm25",
+	} satisfies PathExpression;
+	// @ts-expect-error Testing unsupported type value
+	expect(() =>
+		getValueFromKey({ measurements: [{ pm25: 42 }] }, pathExpression),
+	).toThrow(TypeError);
 });
 
-test('getValueFromKey returns null when key function throws a non-TypeError', () => {
-  expect(
-    getValueFromKey({ pm25: 42 }, () => {
-      throw new Error('unexpected');
-    }),
-  ).toBe(null);
+test("getValueFromKey returns null when key function throws a non-TypeError", () => {
+	expect(
+		getValueFromKey({ pm25: 42 }, () => {
+			throw new Error("unexpected");
+		}),
+	).toBe(null);
 });
 
-test('getValueFromKey returns boolean true primitive directly', () => {
-  expect(getValueFromKey({ is_mobile: false }, true)).toBe(true);
+test("getValueFromKey returns boolean true primitive directly", () => {
+	expect(getValueFromKey({ is_mobile: false }, true)).toBe(true);
 });
 
-test('getValueFromKey returns boolean false primitive directly', () => {
-  expect(getValueFromKey({ is_mobile: true }, false)).toBe(false);
+test("getValueFromKey returns boolean false primitive directly", () => {
+	expect(getValueFromKey({ is_mobile: true }, false)).toBe(false);
 });
 
-test('getValueFromKey returns number primitive directly', () => {
-  expect(getValueFromKey({ interval: 42 }, 3600)).toBe(3600);
+test("getValueFromKey returns number primitive directly", () => {
+	expect(getValueFromKey({ interval: 42 }, 3600)).toBe(3600);
 });
 
-test('getValueFromKey returns zero number primitive directly', () => {
-  expect(getValueFromKey({ interval: 42 }, 0)).toBe(0);
+test("getValueFromKey returns zero number primitive directly", () => {
+	expect(getValueFromKey({ interval: 42 }, 0)).toBe(0);
 });
 
-test('countDecimals returns the right value', () => {
-  expect(countDecimals(7.24)).toBe(2);
+test("countDecimals returns the right value", () => {
+	expect(countDecimals(7.24)).toBe(2);
 });
 
 // test('getMethod returns method by key', () => {
@@ -165,505 +164,540 @@ test('countDecimals returns the right value', () => {
 // });
 
 const record = (value: unknown) => ({ value }) as unknown as SourceRecord;
-const key = 'value';
+const key = "value";
 
-describe('getString', () => {
-  test('returns the string value as-is', () => {
-    expect(getString(record('hello'), key)).toBe('hello');
-  });
+describe("getString", () => {
+	test("returns the string value as-is", () => {
+		expect(getString(record("hello"), key)).toBe("hello");
+	});
 
-  test('coerces a number to string', () => {
-    expect(getString(record(42), key)).toBe('42');
-  });
+	test("coerces a number to string", () => {
+		expect(getString(record(42), key)).toBe("42");
+	});
 
-  test('coerces a boolean to string', () => {
-    expect(getString(record(true), key)).toBe('true');
-  });
+	test("coerces a boolean to string", () => {
+		expect(getString(record(true), key)).toBe("true");
+	});
 
-  test('returns undefined for null', () => {
-    expect(getString(record(null), key)).toBeUndefined();
-  });
+	test("returns undefined for null", () => {
+		expect(getString(record(null), key)).toBeUndefined();
+	});
 
-  test('returns undefined for undefined', () => {
-    expect(getString(record(undefined), key)).toBeUndefined();
-  });
+	test("returns undefined for undefined", () => {
+		expect(getString(record(undefined), key)).toBeUndefined();
+	});
 
-  test('returns empty string for empty string', () => {
-    expect(getString(record(''), key)).toBe('');
-  });
+	test("returns empty string for empty string", () => {
+		expect(getString(record(""), key)).toBe("");
+	});
 
-  test('returns a string for jmespath expression', () => {
-    expect(getString(record(42), { type: 'jmespath', value: 'value' })).toBe(
-      '42',
-    );
-  });
+	test("returns a string for jmespath expression", () => {
+		expect(getString(record(42), { type: "jmespath", value: "value" })).toBe(
+			"42",
+		);
+	});
 
-  test('returns a string for constant value of type string', () => {
-    expect(getString(record(42), { type: 'constant', value: '2' })).toBe('2');
-  });
+	test("returns a string for constant value of type string", () => {
+		expect(getString(record(42), { type: "constant", value: "2" })).toBe("2");
+	});
 
-  test('returns a string for constant value of type number', () => {
-    expect(getString(record(42), { type: 'constant', value: 2 })).toBe('2');
-  });
+	test("returns a string for constant value of type number", () => {
+		expect(getString(record(42), { type: "constant", value: 2 })).toBe("2");
+	});
 });
 
-describe('getNumber', () => {
-  const numberFormat: DecimalDigitGroup = { decimal: 'point' };
+describe("getNumber", () => {
+	const numberFormat: DecimalDigitGroup = { decimal: "point" };
 
-  test('returns a number value as-is', () => {
-    expect(getNumber(record(42), key, numberFormat)).toBe(42);
-  });
+	test("returns a number value as-is", () => {
+		expect(getNumber(record(42), key, numberFormat)).toBe(42);
+	});
 
-  test('coerces a numeric string to number', () => {
-    expect(getNumber(record('3.14'), key, numberFormat)).toBe(3.14);
-  });
+	test("coerces a numeric string to number", () => {
+		expect(getNumber(record("3.14"), key, numberFormat)).toBe(3.14);
+	});
 
-  test('returns undefined for null', () => {
-    expect(getNumber(record(null), key, numberFormat)).toBeUndefined();
-  });
+	test("returns undefined for null", () => {
+		expect(getNumber(record(null), key, numberFormat)).toBeUndefined();
+	});
 
-  test('returns undefined for undefined', () => {
-    expect(getNumber(record(undefined), key, numberFormat)).toBeUndefined();
-  });
+	test("returns undefined for undefined", () => {
+		expect(getNumber(record(undefined), key, numberFormat)).toBeUndefined();
+	});
 
-  test('returns undefined for non-numeric string', () => {
-    expect(getNumber(record('abc'), key, numberFormat)).toBeNaN();
-  });
+	test("returns undefined for non-numeric string", () => {
+		expect(getNumber(record("abc"), key, numberFormat)).toBeNaN();
+	});
 
-  test('returns undefined for empty string', () => {
-    expect(getNumber(record(''), key, numberFormat)).toBeUndefined();
-  });
+	test("returns undefined for empty string", () => {
+		expect(getNumber(record(""), key, numberFormat)).toBeUndefined();
+	});
 
-  test("returns 0 for '0'", () => {
-    expect(getNumber(record('0'), key, numberFormat)).toBe(0);
-  });
+	test("returns 0 for '0'", () => {
+		expect(getNumber(record("0"), key, numberFormat)).toBe(0);
+	});
 
-  test('returns number 0 for jmespath expression', () => {
-    expect(
-      getNumber(
-        record('0'),
-        { type: 'jmespath', value: 'value' },
-        numberFormat,
-      ),
-    ).toBe(0);
-  });
+	test("returns number 0 for jmespath expression", () => {
+		expect(
+			getNumber(
+				record("0"),
+				{ type: "jmespath", value: "value" },
+				numberFormat,
+			),
+		).toBe(0);
+	});
 
-  test('returns constant number for constant value string', () => {
-    expect(
-      getNumber(record('0'), { type: 'constant', value: '42' }, numberFormat),
-    ).toBe(42);
-  });
+	test("returns constant number for constant value string", () => {
+		expect(
+			getNumber(record("0"), { type: "constant", value: "42" }, numberFormat),
+		).toBe(42);
+	});
 
-  test('returns constant number for constant value number', () => {
-    expect(
-      getNumber(record('0'), { type: 'constant', value: 42 }, numberFormat),
-    ).toBe(42);
-  });
+	test("returns constant number for constant value number", () => {
+		expect(
+			getNumber(record("0"), { type: "constant", value: 42 }, numberFormat),
+		).toBe(42);
+	});
 
-  test('returns number primitive directly', () => {
-    expect(getNumber(record(42), 3600, numberFormat)).toBe(3600);
-  });
+	test("returns number primitive directly", () => {
+		expect(getNumber(record(42), 3600, numberFormat)).toBe(3600);
+	});
 
-  test('returns zero number primitive directly', () => {
-    expect(getNumber(record(42), 0, numberFormat)).toBe(0);
-  });
+	test("returns zero number primitive directly", () => {
+		expect(getNumber(record(42), 0, numberFormat)).toBe(0);
+	});
 
-  test('parses a comma-decimal string with matching numberFormat', () => {
-    const format: DecimalDigitGroup = { decimal: 'comma' };
-    expect(getNumber(record('3,14'), key, format)).toBe(3.14);
-  });
+	test("parses a comma-decimal string with matching numberFormat", () => {
+		const format: DecimalDigitGroup = { decimal: "comma" };
+		expect(getNumber(record("3,14"), key, format)).toBe(3.14);
+	});
 });
 
-describe('getBoolean', () => {
-  test('returns true for boolean true', () => {
-    expect(getBoolean(record(true), key)).toBe(true);
-  });
+describe("getBoolean", () => {
+	test("returns true for boolean true", () => {
+		expect(getBoolean(record(true), key)).toBe(true);
+	});
 
-  test('returns false for boolean false', () => {
-    expect(getBoolean(record(false), key)).toBe(false);
-  });
+	test("returns false for boolean false", () => {
+		expect(getBoolean(record(false), key)).toBe(false);
+	});
 
-  test('returns false for string "false"', () => {
-    expect(getBoolean(record('false'), key)).toBe(false);
-  });
+	test('returns false for string "false"', () => {
+		expect(getBoolean(record("false"), key)).toBe(false);
+	});
 
-  test('returns false for string "FALSE"', () => {
-    expect(getBoolean(record('FALSE'), key)).toBe(false);
-  });
+	test('returns false for string "FALSE"', () => {
+		expect(getBoolean(record("FALSE"), key)).toBe(false);
+	});
 
-  test('returns false for string "0"', () => {
-    expect(getBoolean(record('0'), key)).toBe(false);
-  });
+	test('returns false for string "0"', () => {
+		expect(getBoolean(record("0"), key)).toBe(false);
+	});
 
-  test('returns true for string "true"', () => {
-    expect(getBoolean(record('true'), key)).toBe(true);
-  });
+	test('returns true for string "true"', () => {
+		expect(getBoolean(record("true"), key)).toBe(true);
+	});
 
-  test('returns true for string "TRUE"', () => {
-    expect(getBoolean(record('TRUE'), key)).toBe(true);
-  });
+	test('returns true for string "TRUE"', () => {
+		expect(getBoolean(record("TRUE"), key)).toBe(true);
+	});
 
-  test('returns true for string "1"', () => {
-    expect(getBoolean(record('1'), key)).toBe(true);
-  });
+	test('returns true for string "1"', () => {
+		expect(getBoolean(record("1"), key)).toBe(true);
+	});
 
-  test('returns false for null', () => {
-    expect(getBoolean(record(null), key)).toBe(false);
-  });
+	test("returns false for null", () => {
+		expect(getBoolean(record(null), key)).toBe(false);
+	});
 
-  test('returns false for empty string', () => {
-    expect(getBoolean(record(''), key)).toBe(false);
-  });
+	test("returns false for empty string", () => {
+		expect(getBoolean(record(""), key)).toBe(false);
+	});
 
-  test('returns true for a non-empty arbitrary string', () => {
-    expect(getBoolean(record('some-value'), key)).toBe(true);
-  });
+	test("returns true for a non-empty arbitrary string", () => {
+		expect(getBoolean(record("some-value"), key)).toBe(true);
+	});
 
-  test('returns true when key is literal true', () => {
-    expect(getBoolean(record(false), true)).toBe(true);
-  });
+	test("returns true when key is literal true", () => {
+		expect(getBoolean(record(false), true)).toBe(true);
+	});
 
-  test('returns false when key is literal false', () => {
-    expect(getBoolean(record(true), false)).toBe(false);
-  });
+	test("returns false when key is literal false", () => {
+		expect(getBoolean(record(true), false)).toBe(false);
+	});
 });
 
-describe('getArray tests', () => {
-  test('returns array for string array', () => {
-    expect(getArray(record(['some-value']), key)).toStrictEqual(['some-value']);
-  });
-  test('returns array for string', () => {
-    expect(getArray(record('some-value'), key)).toStrictEqual(['some-value']);
-  });
-  test('returns array for numeric array', () => {
-    expect(getArray(record([0]), key)).toStrictEqual([0]);
-  });
-  test('returns array for number', () => {
-    expect(getArray(record(0), key)).toStrictEqual([0]);
-  });
-  test('returns undefined for undefined', () => {
-    expect(getArray(record(undefined), key)).toBeUndefined();
-  });
-  test('returns undefined for null', () => {
-    expect(getArray(record(null), key)).toBeUndefined();
-  });
-  test('returns empty array for array', () => {
-    expect(getArray(record([]), key)).toStrictEqual([]);
-  });
+describe("getArray tests", () => {
+	test("returns array for string array", () => {
+		expect(getArray(record(["some-value"]), key)).toStrictEqual(["some-value"]);
+	});
+	test("returns array for string", () => {
+		expect(getArray(record("some-value"), key)).toStrictEqual(["some-value"]);
+	});
+	test("returns array for numeric array", () => {
+		expect(getArray(record([0]), key)).toStrictEqual([0]);
+	});
+	test("returns array for number", () => {
+		expect(getArray(record(0), key)).toStrictEqual([0]);
+	});
+	test("returns undefined for undefined", () => {
+		expect(getArray(record(undefined), key)).toBeUndefined();
+	});
+	test("returns undefined for null", () => {
+		expect(getArray(record(null), key)).toBeUndefined();
+	});
+	test("returns empty array for array", () => {
+		expect(getArray(record([]), key)).toStrictEqual([]);
+	});
 
-  test('returns array for path expression', () => {
-    expect(
-      getArray(record('some-value'), {
-        type: 'jmespath',
-        value: 'value',
-      } satisfies PathExpression),
-    ).toStrictEqual(['some-value']);
-  });
+	test("returns array for path expression", () => {
+		expect(
+			getArray(record("some-value"), {
+				type: "jmespath",
+				value: "value",
+			} satisfies PathExpression),
+		).toStrictEqual(["some-value"]);
+	});
 
-  test('returns array for constant value', () => {
-    expect(
-      getArray(record('some-value'), {
-        type: 'constant',
-        value: 42,
-      } satisfies ConstantValue),
-    ).toStrictEqual([42]);
-  });
+	test("returns array for constant value", () => {
+		expect(
+			getArray(record("some-value"), {
+				type: "constant",
+				value: 42,
+			} satisfies ConstantValue),
+		).toStrictEqual([42]);
+	});
 });
 
 // Test cases based on "common" cases as described in the table here:
 // https://en.wikipedia.org/wiki/Decimal_separator#Other_numeral_systems
 
-describe('normalizeNumericString', () => {
-  describe('comma grouped, point decimal', () => {
-    const format: DecimalDigitGroup = { decimal: 'point', digitGroup: 'comma' };
+describe("normalizeNumericString", () => {
+	describe("comma grouped, point decimal", () => {
+		const format: DecimalDigitGroup = { decimal: "point", digitGroup: "comma" };
 
-    test('parses a fully-formatted number', () => {
-      expect(normalizeNumericString('1,234,567.89', format)).toBe('1234567.89');
-    });
+		test("parses a fully-formatted number", () => {
+			expect(normalizeNumericString("1,234,567.89", format)).toBe("1234567.89");
+		});
 
-    test('parses an integer with group separators', () => {
-      expect(normalizeNumericString('1,234,567', format)).toBe('1234567');
-    });
+		test("parses an integer with group separators", () => {
+			expect(normalizeNumericString("1,234,567", format)).toBe("1234567");
+		});
 
-    test('parses a number without group separator', () => {
-      expect(normalizeNumericString('1234567.89', format)).toBe('1234567.89');
-    });
+		test("parses a number without group separator", () => {
+			expect(normalizeNumericString("1234567.89", format)).toBe("1234567.89");
+		});
 
-    test('parses zero', () => {
-      expect(normalizeNumericString('0.00', format)).toBe('0.00');
-    });
+		test("parses zero", () => {
+			expect(normalizeNumericString("0.00", format)).toBe("0.00");
+		});
 
-    test('parses a negative number', () => {
-      expect(normalizeNumericString('-1,234.56', format)).toBe('-1234.56');
-    });
+		test("parses a negative number", () => {
+			expect(normalizeNumericString("-1,234.56", format)).toBe("-1234.56");
+		});
 
-    test('returns empty string for empty input', () => {
-      expect(normalizeNumericString('  ', format)).toBe('');
-    });
-  });
+		test("returns empty string for empty input", () => {
+			expect(normalizeNumericString("  ", format)).toBe("");
+		});
+	});
 
-  describe('no group, point decimal', () => {
-    const format: DecimalDigitGroup = { decimal: 'point' };
+	describe("no group, point decimal", () => {
+		const format: DecimalDigitGroup = { decimal: "point" };
 
-    test('parses a plain integer', () => {
-      expect(normalizeNumericString('1234567', format)).toBe('1234567');
-    });
+		test("parses a plain integer", () => {
+			expect(normalizeNumericString("1234567", format)).toBe("1234567");
+		});
 
-    test('parses a number with decimal part', () => {
-      expect(normalizeNumericString('1234567.89', format)).toBe('1234567.89');
-    });
+		test("parses a number with decimal part", () => {
+			expect(normalizeNumericString("1234567.89", format)).toBe("1234567.89");
+		});
 
-    test('returns empty string for empty input', () => {
-      expect(normalizeNumericString('', format)).toBe('');
-    });
-  });
+		test("returns empty string for empty input", () => {
+			expect(normalizeNumericString("", format)).toBe("");
+		});
+	});
 
-  describe('no group, comma decimal', () => {
-    const format: DecimalDigitGroup = { decimal: 'comma' };
+	describe("no group, comma decimal", () => {
+		const format: DecimalDigitGroup = { decimal: "comma" };
 
-    test('parses a plain number and converts comma to period', () => {
-      expect(normalizeNumericString('1234567,89', format)).toBe('1234567.89');
-    });
+		test("parses a plain number and converts comma to period", () => {
+			expect(normalizeNumericString("1234567,89", format)).toBe("1234567.89");
+		});
 
-    test('parses an integer', () => {
-      expect(normalizeNumericString('1234567', format)).toBe('1234567');
-    });
-  });
+		test("parses an integer", () => {
+			expect(normalizeNumericString("1234567", format)).toBe("1234567");
+		});
+	});
 
-  describe('dot grouped, comma decimal', () => {
-    const format: DecimalDigitGroup = { decimal: 'comma', digitGroup: 'dot' };
+	describe("dot grouped, comma decimal", () => {
+		const format: DecimalDigitGroup = { decimal: "comma", digitGroup: "dot" };
 
-    test('parses a comma decimal got grouped number', () => {
-      expect(normalizeNumericString('1.234.567,89', format)).toBe('1234567.89');
-    });
+		test("parses a comma decimal got grouped number", () => {
+			expect(normalizeNumericString("1.234.567,89", format)).toBe("1234567.89");
+		});
 
-    test('parses an integer with dot separators', () => {
-      expect(normalizeNumericString('1.234.567', format)).toBe('1234567');
-    });
+		test("parses an integer with dot separators", () => {
+			expect(normalizeNumericString("1.234.567", format)).toBe("1234567");
+		});
 
-    test('parses a small number', () => {
-      expect(normalizeNumericString('1.000,00', format)).toBe('1000.00');
-    });
-  });
+		test("parses a small number", () => {
+			expect(normalizeNumericString("1.000,00", format)).toBe("1000.00");
+		});
+	});
 
-  describe('comma grouped, interpunct decimal', () => {
-    const format: DecimalDigitGroup = {
-      decimal: 'interpunct',
-      digitGroup: 'comma',
-    };
+	describe("comma grouped, interpunct decimal", () => {
+		const format: DecimalDigitGroup = {
+			decimal: "interpunct",
+			digitGroup: "comma",
+		};
 
-    test('parses a interpunct comma grouped number', () => {
-      expect(normalizeNumericString('1,234,567\u00B789', format)).toBe(
-        '1234567.89',
-      );
-    });
+		test("parses a interpunct comma grouped number", () => {
+			expect(normalizeNumericString("1,234,567\u00B789", format)).toBe(
+				"1234567.89",
+			);
+		});
 
-    test('parses without group separator', () => {
-      expect(normalizeNumericString('1234567\u00B789', format)).toBe(
-        '1234567.89',
-      );
-    });
-  });
+		test("parses without group separator", () => {
+			expect(normalizeNumericString("1234567\u00B789", format)).toBe(
+				"1234567.89",
+			);
+		});
+	});
 
-  describe('Indian number grouping', () => {
-    const format: DecimalDigitGroup = { decimal: 'point', digitGroup: 'comma' };
+	describe("Indian number grouping", () => {
+		const format: DecimalDigitGroup = { decimal: "point", digitGroup: "comma" };
 
-    test('parses Indian-style grouping', () => {
-      expect(normalizeNumericString('12,34,567.89', format)).toBe('1234567.89');
-    });
-  });
+		test("parses Indian-style grouping", () => {
+			expect(normalizeNumericString("12,34,567.89", format)).toBe("1234567.89");
+		});
+	});
 
-  describe('apostrophe grouped, point decimal', () => {
-    const format: DecimalDigitGroup = {
-      decimal: 'point',
-      digitGroup: 'apostrophe',
-    };
+	describe("apostrophe grouped, point decimal", () => {
+		const format: DecimalDigitGroup = {
+			decimal: "point",
+			digitGroup: "apostrophe",
+		};
 
-    test('parses an apostrophe grouped point decimal number', () => {
-      expect(normalizeNumericString("1'234'567.89", format)).toBe('1234567.89');
-    });
+		test("parses an apostrophe grouped point decimal number", () => {
+			expect(normalizeNumericString("1'234'567.89", format)).toBe("1234567.89");
+		});
 
-    test('parses an integer with apostrophe groups', () => {
-      expect(normalizeNumericString("1'234'567", format)).toBe('1234567');
-    });
-  });
+		test("parses an integer with apostrophe groups", () => {
+			expect(normalizeNumericString("1'234'567", format)).toBe("1234567");
+		});
+	});
 
-  describe('apostrophe grouped, comma decimal', () => {
-    const format: DecimalDigitGroup = {
-      decimal: 'comma',
-      digitGroup: 'apostrophe',
-    };
+	describe("apostrophe grouped, comma decimal", () => {
+		const format: DecimalDigitGroup = {
+			decimal: "comma",
+			digitGroup: "apostrophe",
+		};
 
-    test('parses an apostophe grouped comma decimal number', () => {
-      expect(normalizeNumericString("1'234'567,89", format)).toBe('1234567.89');
-    });
+		test("parses an apostophe grouped comma decimal number", () => {
+			expect(normalizeNumericString("1'234'567,89", format)).toBe("1234567.89");
+		});
 
-    test('parses an integer with apostrophe groups', () => {
-      expect(normalizeNumericString("1'234'567", format)).toBe('1234567');
-    });
-  });
+		test("parses an integer with apostrophe groups", () => {
+			expect(normalizeNumericString("1'234'567", format)).toBe("1234567");
+		});
+	});
 
-  describe('space grouped, comma decimal', () => {
-    const format: DecimalDigitGroup = { decimal: 'comma', digitGroup: 'space' };
+	describe("space grouped, comma decimal", () => {
+		const format: DecimalDigitGroup = { decimal: "comma", digitGroup: "space" };
 
-    test('parses space as group separator', () => {
-      expect(normalizeNumericString('1 234 567,89', format)).toBe('1234567.89');
-    });
+		test("parses space as group separator", () => {
+			expect(normalizeNumericString("1 234 567,89", format)).toBe("1234567.89");
+		});
 
-    test('parses non-breaking space (U+00A0) as group separator', () => {
-      expect(normalizeNumericString('1\u00A0234\u00A0567,89', format)).toBe(
-        '1234567.89',
-      );
-    });
+		test("parses non-breaking space (U+00A0) as group separator", () => {
+			expect(normalizeNumericString("1\u00A0234\u00A0567,89", format)).toBe(
+				"1234567.89",
+			);
+		});
 
-    test('parses narrow no-break space (U+202F) as group separator', () => {
-      expect(normalizeNumericString('1\u202F234\u202F567,89', format)).toBe(
-        '1234567.89',
-      );
-    });
+		test("parses narrow no-break space (U+202F) as group separator", () => {
+			expect(normalizeNumericString("1\u202F234\u202F567,89", format)).toBe(
+				"1234567.89",
+			);
+		});
 
-    test('parses an integer with space separators', () => {
-      expect(normalizeNumericString('1 234 567', format)).toBe('1234567');
-    });
-  });
+		test("parses an integer with space separators", () => {
+			expect(normalizeNumericString("1 234 567", format)).toBe("1234567");
+		});
+	});
 
-  describe('arabic decimal separator (U+066B)', () => {
-    const format: DecimalDigitGroup = { decimal: 'arabic' };
+	describe("arabic decimal separator (U+066B)", () => {
+		const format: DecimalDigitGroup = { decimal: "arabic" };
 
-    test('parses a number with arabic decimal comma', () => {
-      expect(normalizeNumericString('1234567\u066B89', format)).toBe(
-        '1234567.89',
-      );
-    });
-  });
+		test("parses a number with arabic decimal comma", () => {
+			expect(normalizeNumericString("1234567\u066B89", format)).toBe(
+				"1234567.89",
+			);
+		});
+	});
 });
 
-describe('jmespath()', () => {
-  test('Creates a PathExpression', () => {
-    const result = jmespath('device.logging.interval');
+describe("jmespath()", () => {
+	test("Creates a PathExpression", () => {
+		const result = jmespath("device.logging.interval");
 
-    expect(result).toEqual({
-      type: 'jmespath',
-      value: 'device.logging.interval',
-    });
-  });
+		expect(result).toEqual({
+			type: "jmespath",
+			value: "device.logging.interval",
+		});
+	});
 });
 
-describe('constant()', () => {
-  test('Create a ConstantValue with a number', () => {
-    const result = constant(3600);
+describe("constant()", () => {
+	test("Create a ConstantValue with a number", () => {
+		const result = constant(3600);
 
-    expect(result).toEqual({
-      type: 'constant',
-      value: 3600,
-    });
-  });
+		expect(result).toEqual({
+			type: "constant",
+			value: 3600,
+		});
+	});
 
-  test('Create a ConstantValue with a string', () => {
-    const result = constant('foo');
+	test("Create a ConstantValue with a string", () => {
+		const result = constant("foo");
 
-    expect(result).toEqual({
-      type: 'constant',
-      value: 'foo',
-    });
-  });
+		expect(result).toEqual({
+			type: "constant",
+			value: "foo",
+		});
+	});
 
-  test('Create a ConstantValue with a boolean', () => {
-    const result = constant(true);
+	test("Create a ConstantValue with a boolean", () => {
+		const result = constant(true);
 
-    expect(result).toEqual({
-      type: 'constant',
-      value: true,
-    });
-  });
+		expect(result).toEqual({
+			type: "constant",
+			value: true,
+		});
+	});
 });
 
-describe('sanitizeManufacturerModelKeySegment', () => {
-  test('returns undefined for empty or whitespace-only input', () => {
-    expect(sanitizeKeyName('')).toBeUndefined();
-    expect(sanitizeKeyName('   ')).toBeUndefined();
-    expect(sanitizeKeyName(undefined)).toBeUndefined();
-  });
+describe("sanitizeManufacturerModelKeySegment", () => {
+	test("returns undefined for empty or whitespace-only input", () => {
+		expect(sanitizeKeyName("")).toBeUndefined();
+		expect(sanitizeKeyName("   ")).toBeUndefined();
+		expect(sanitizeKeyName(undefined)).toBeUndefined();
+	});
 
-  test('trims surrounding whitespace', () => {
-    expect(sanitizeKeyName('  Met One  ')).toBe('Met One');
-  });
+	test("trims surrounding whitespace", () => {
+		expect(sanitizeKeyName("  Met One  ")).toBe("Met One");
+	});
 
-  test('replaces slashes with a dash', () => {
-    expect(sanitizeKeyName('Met/One')).toBe('Met-One');
-  });
+	test("replaces slashes with a dash", () => {
+		expect(sanitizeKeyName("Met/One")).toBe("Met-One");
+	});
 
-  test('replaces double colons with a single dash', () => {
-    expect(sanitizeKeyName('Met::One')).toBe('Met-One');
-  });
+	test("replaces double colons with a single dash", () => {
+		expect(sanitizeKeyName("Met::One")).toBe("Met-One");
+	});
 
-  test('collapses mixed runs of delimiters into one dash', () => {
-    expect(sanitizeKeyName('Met/::One')).toBe('Met-One');
-  });
+	test("collapses mixed runs of delimiters into one dash", () => {
+		expect(sanitizeKeyName("Met/::One")).toBe("Met-One");
+	});
 
-  test('strips leading/trailing delimiters entirely rather than leaving a dash', () => {
-    expect(sanitizeKeyName('/Met One/')).toBe('Met One');
-    expect(sanitizeKeyName('::Met One::')).toBe('Met One');
-  });
+	test("strips leading/trailing delimiters entirely rather than leaving a dash", () => {
+		expect(sanitizeKeyName("/Met One/")).toBe("Met One");
+		expect(sanitizeKeyName("::Met One::")).toBe("Met One");
+	});
 
-  test('leaves ordinary names unaffected', () => {
-    expect(sanitizeKeyName('Met One')).toBe('Met One');
-  });
+	test("leaves ordinary names unaffected", () => {
+		expect(sanitizeKeyName("Met One")).toBe("Met One");
+	});
 });
 
-describe('toUnixSeconds', () => {
-  test('converts a number in seconds unchanged', () => {
-    expect(toUnixSeconds(466738980, 'seconds')).toBe(466738980);
-  });
+describe("toUnixSeconds", () => {
+	test("converts a number in seconds unchanged", () => {
+		expect(toUnixSeconds(466738980, "seconds")).toBe(466738980);
+	});
 
-  test('converts a numeric string in seconds', () => {
-    expect(toUnixSeconds('466738980', 'seconds')).toBe(466738980);
-  });
+	test("converts a numeric string in seconds", () => {
+		expect(toUnixSeconds("466738980", "seconds")).toBe(466738980);
+	});
 
-  test('converts a number in milliseconds to seconds', () => {
-    expect(toUnixSeconds(466738980000, 'milliseconds')).toBe(466738980);
-  });
+	test("converts a number in milliseconds to seconds", () => {
+		expect(toUnixSeconds(466738980000, "milliseconds")).toBe(466738980);
+	});
 
-  test('converts a numeric string in milliseconds to seconds', () => {
-    expect(toUnixSeconds('466738980000', 'milliseconds')).toBe(466738980);
-  });
+	test("converts a numeric string in milliseconds to seconds", () => {
+		expect(toUnixSeconds("466738980000", "milliseconds")).toBe(466738980);
+	});
 
-  test('preserves fractional seconds', () => {
-    expect(toUnixSeconds(466738980.5, 'seconds')).toBe(466738980.5);
-  });
+	test("preserves fractional seconds", () => {
+		expect(toUnixSeconds(466738980.5, "seconds")).toBe(466738980.5);
+	});
 
-  test('preserves fractional result when converting milliseconds', () => {
-    expect(toUnixSeconds(466738980500, 'milliseconds')).toBeCloseTo(
-      466738980.5,
-    );
-  });
+	test("preserves fractional result when converting milliseconds", () => {
+		expect(toUnixSeconds(466738980500, "milliseconds")).toBeCloseTo(
+			466738980.5,
+		);
+	});
 
-  test('throws when value is a non-numeric string', () => {
-    expect(() => toUnixSeconds('not-a-number', 'seconds')).toThrow(
-      DatetimeError,
-    );
-  });
+	test("throws when value is a non-numeric string", () => {
+		expect(() => toUnixSeconds("not-a-number", "seconds")).toThrow(
+			DatetimeError,
+		);
+	});
 
-  test('throws when value is undefined', () => {
-    expect(() => toUnixSeconds(undefined, 'seconds')).toThrow(DatetimeError);
-  });
+	test("throws when value is undefined", () => {
+		expect(() => toUnixSeconds(undefined, "seconds")).toThrow(DatetimeError);
+	});
 
-  test('throws when value is null', () => {
-    expect(() => toUnixSeconds(null, 'seconds')).toThrow(DatetimeError);
-  });
+	test("throws when value is null", () => {
+		expect(() => toUnixSeconds(null, "seconds")).toThrow(DatetimeError);
+	});
 
-  test('throws when value is an empty string', () => {
-    expect(() => toUnixSeconds('', 'seconds')).toThrow(DatetimeError);
-  });
+	test("throws when value is an empty string", () => {
+		expect(() => toUnixSeconds("", "seconds")).toThrow(DatetimeError);
+	});
 
-  test('throws when value is an object', () => {
-    expect(() => toUnixSeconds({}, 'seconds')).toThrow(DatetimeError);
-  });
+	test("throws when value is an object", () => {
+		expect(() => toUnixSeconds({}, "seconds")).toThrow(DatetimeError);
+	});
 
-  test('handles zero', () => {
-    expect(toUnixSeconds(0, 'seconds')).toBe(0);
-    expect(toUnixSeconds('0', 'seconds')).toBe(0);
-    expect(toUnixSeconds(0, 'milliseconds')).toBe(0);
-    expect(toUnixSeconds('0', 'milliseconds')).toBe(0);
-  });
+	test("handles zero", () => {
+		expect(toUnixSeconds(0, "seconds")).toBe(0);
+		expect(toUnixSeconds("0", "seconds")).toBe(0);
+		expect(toUnixSeconds(0, "milliseconds")).toBe(0);
+		expect(toUnixSeconds("0", "milliseconds")).toBe(0);
+	});
+});
+
+describe("isBlank", () => {
+	test("null evaluates true", () => {
+		expect(isBlank(null)).toBe(true);
+	});
+
+	test("undefined evaluates true", () => {
+		expect(isBlank(undefined)).toBe(true);
+	});
+
+	test("empty string, no characters evaluadtes true", () => {
+		expect(isBlank("")).toBe(true);
+	});
+
+	test("empty string, spaces-only evaluates true", () => {
+		expect(isBlank("  ")).toBe(true);
+	});
+
+	test("string evaluates false", () => {
+		expect(isBlank("foo")).toBe(false);
+	});
+
+	test("zero evaluates false", () => {
+		expect(isBlank(0)).toBe(false);
+	});
+
+	test("number evaluates false", () => {
+		expect(isBlank(42)).toBe(false);
+	});
+
+	test("booleans evaluate false", () => {
+		expect(isBlank(true)).toBe(false);
+		expect(isBlank(false)).toBe(false);
+	});
 });

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -180,7 +180,9 @@ export const getNumber = (
 	numberFormat: DecimalDigitGroup,
 ): number | undefined => {
 	let value = getValueFromKey(data, key) as number | null | string;
-	if (value == null || value === "") return undefined;
+	if (isBlank(value)) {
+		return undefined;
+	}
 	if (typeof value === "string") {
 		value = normalizeNumericString(value, numberFormat);
 	}
@@ -201,8 +203,12 @@ export const getBoolean = (
 	const value = getValueFromKey(data, key);
 	if (typeof value === "string") {
 		const lower = value.toLowerCase().trim();
-		if (lower === "false" || lower === "0") return false;
-		if (lower === "true" || lower === "1") return true;
+		if (lower === "false" || lower === "0") {
+			return false;
+		}
+		if (lower === "true" || lower === "1") {
+			return true;
+		}
 	}
 	return Boolean(value);
 };
@@ -225,8 +231,12 @@ export const getArray = (
 		| string
 		| number[]
 		| string[];
-	if (value == null || value === "") return undefined;
-	if (!Array.isArray(value)) return [value];
+	if (isBlank(value)) {
+		return undefined;
+	}
+	if (!Array.isArray(value)) {
+		return [value];
+	}
 	return value;
 };
 
@@ -288,10 +298,10 @@ export function normalizeNumericString(
 	value: string,
 	format: DecimalDigitGroup,
 ): string {
-	let v = value.trim();
-	if (v === "") {
+	if (isBlank(value)) {
 		return "";
 	}
+	let v = value.trim();
 
 	const { decimal, digitGroup } = format;
 	if (digitGroup) {
@@ -380,11 +390,7 @@ export function sanitizeKeyName(value?: string): string | undefined {
  * toUnixSeconds("466738980000", "milliseconds"); // 466738980
  */
 export function toUnixSeconds(value: unknown, type: UnixDatetimeType): number {
-	const isBlank =
-		value === null ||
-		value === undefined ||
-		(typeof value === "string" && value.trim() === "");
-	const num = isBlank ? NaN : Number(value);
+	const num = isBlank(value) ? NaN : Number(value);
 
 	if (Number.isNaN(num)) {
 		throw new DatetimeError(
@@ -393,4 +399,30 @@ export function toUnixSeconds(value: unknown, type: UnixDatetimeType): number {
 		);
 	}
 	return type === "milliseconds" ? num / 1000 : num;
+}
+
+/**
+ * Determines whether a value should be treated as "blank" (i.e. absent or empty)
+ *
+ * @param value - The value to check.
+ * @returns `true` if the value is `null`, `undefined`, or a whitespace-only
+ * string; `false` otherwise.
+ *
+ * @example
+ * ```ts
+ * isBlank(null);        // true
+ * isBlank(undefined);   // true
+ * isBlank("");          // true
+ * isBlank(" ");         // true
+ * isBlank("foo");       // false
+ * isBlank(0);           // false
+ * isBlank(false);       // false
+ * ```
+ */
+export function isBlank(value: unknown): boolean {
+	return (
+		value === null ||
+		value === undefined ||
+		(typeof value === "string" && value.trim() === "")
+	);
 }

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -235,7 +235,7 @@ export const getArray = (
 		return undefined;
 	}
 	if (!Array.isArray(value)) {
-		return [value];
+		return [value as string | number];
 	}
 	return value;
 };

--- a/src/node/client.spec.ts
+++ b/src/node/client.spec.ts
@@ -43,9 +43,10 @@ const handlers = [
 				station: "ts1",
 				datetime: "2024-01-01T00:00:00-08:00",
 				particulate_matter_25: 10,
+				particulate_matter_10: 0,
 				tempf: 80,
 			},
-			{ station: "ts1", datetime: "2024-01-01T01:00:00-08:00", tempf: 80 },
+					{ station: "ts1", datetime: "2024-01-01T01:00:00-08:00", tempf: 80 },
 		]);
 	}),
   http.get("https://blah.org/test-provider/measurements-and-locations", async () => {
@@ -55,6 +56,7 @@ const handlers = [
 				  station: "ts1",
 				  datetime: "2024-01-01T00:00:00-08:00",
 				  particulate_matter_25: 10,
+				  particulate_matter_10: 0,
 				  tempf: 80,
 			  },
 			  { station: "ts1", datetime: "2024-01-01T01:00:00-08:00", tempf: 80 },
@@ -78,6 +80,7 @@ const handlers = [
                     station: "ts1",
                     datetime: "2024-01-01T00:00:00-08:00",
                     particulate_matter_25: 10,
+                    particulate_matter_10: 0, 
                     tempf: 80,
                 },
                 { station: "ts1", datetime: "2024-01-01T01:00:00-08:00", tempf: 80 },
@@ -105,6 +108,7 @@ http.get("https://blah.org/test-provider/wrapped-wide", async () => {
                 longitude: -123.12121,
                 datetime: "2024-01-01T00:00:00-08:00",
                 particulate_matter_25: 10,
+                particulate_matter_10: 0,
                 tempf: 80,
             },
             {
@@ -136,12 +140,18 @@ http.get("https://blah.org/test-provider/wrapped-wide", async () => {
 					parameter: "particulate_matter_25",
 					value: 10,
 				},
-				{
-					station: "ts1",
-					datetime: "2024-01-01T00:00:00-08:00",
-					parameter: "tempf",
-					value: 80,
-				},
+        {
+          station: "ts1",
+          datetime: "2024-01-01T00:00:00-08:00",
+          parameter: "particulate_matter_10",
+          value: 0,
+        },
+        {
+          station: "ts1",
+          datetime: "2024-01-01T00:00:00-08:00",
+        	parameter: "tempf",
+          value: 80,
+    		},
 				{
 					station: "ts1",
 					datetime: "2024-01-01T01:00:00-08:00",
@@ -164,27 +174,14 @@ http.get("https://blah.org/test-provider/wrapped-wide", async () => {
 			],
 			sensors: [
 				{ station: "ts1", parameter: "particulate_matter_25" },
+				{ station: "ts1", parameter: "particulate_matter_10" },
 				{ station: "ts1", parameter: "tempf" },
 			],
 			measurements: [
-				{
-					station: "ts1",
-					datetime: "2024-01-01T00:00:00-08:00",
-					parameter: "particulate_matter_25",
-					value: 10,
-				},
-				{
-					station: "ts1",
-					datetime: "2024-01-01T00:00:00-08:00",
-					parameter: "tempf",
-					value: 80,
-				},
-				{
-					station: "ts1",
-					datetime: "2024-01-01T01:00:00-08:00",
-					parameter: "tempf",
-					value: 80,
-				},
+				{ station: "ts1", datetime: "2024-01-01T00:00:00-08:00", parameter: "particulate_matter_25", value: 10 },
+				{ station: "ts1", datetime: "2024-01-01T00:00:00-08:00", parameter: "particulate_matter_10", value: 0 },
+				{ station: "ts1", datetime: "2024-01-01T00:00:00-08:00", parameter: "tempf", value: 80 },
+				{ station: "ts1", datetime: "2024-01-01T01:00:00-08:00", parameter: "tempf", value: 80 },
 			],
 		});
 	}),
@@ -268,6 +265,7 @@ describe("Client with data in wide format", () => {
 		parameters = [
 			// provider_parameter_name: { parameter: 'openaq_name', unit: 'provider_units', key: "provider field" }
 			{ parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
+			{ parameter: "pm10", unit: "ug/m3", key: "particulate_matter_10" },
 			{ parameter: "temperature", unit: "f", key: "tempf" },
 		];
 	}
@@ -281,6 +279,7 @@ describe("Client with data in wide format", () => {
 		const cln = new JsonClient();
 		expect(cln.parameters.map((o) => o.key)).toStrictEqual([
 			"particulate_matter_25",
+			"particulate_matter_10",
 			"tempf",
 		]);
 	});
@@ -319,6 +318,7 @@ describe("Client with data split between two different resources", () => {
 		isMobile = () => false;
 		parameters = [
 			{ parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
+			{ parameter: "pm10", unit: "ug/m3", key: "particulate_matter_10" },
 			{ parameter: "temperature", unit: "f", key: "tempf" },
 		];
 	}
@@ -355,6 +355,7 @@ describe("Client with an indexed resource that returns a ResourceData object", (
 		isMobile = () => false;
 		parameters = [
 			{ parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
+			{ parameter: "pm10", unit: "ug/m3", key: "particulate_matter_10" },
 			{ parameter: "temperature", unit: "f", key: "tempf" },
 		];
 	}
@@ -364,7 +365,6 @@ describe("Client with an indexed resource that returns a ResourceData object", (
 		const data = await cln.load();
 		expect(data).toStrictEqual(expectedOutput);
 	});
-
 });
 
 describe("Client with data in long format", () => {
@@ -384,6 +384,7 @@ describe("Client with data in long format", () => {
 		isMobile = () => false;
 		parameters = [
 			{ parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
+			{ parameter: "pm10", unit: "ug/m3", key: "particulate_matter_10" },
 			{ parameter: "temperature", unit: "f", key: "tempf" },
 		];
 	}
@@ -412,6 +413,7 @@ describe("Provider that passes sensor data", () => {
 		isMobile = () => false;
 		parameters = [
 			{ parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
+			{ parameter: "pm10", unit: "ug/m3", key: "particulate_matter_10" },
 			{ parameter: "temperature", unit: "f", key: "tempf" },
 		];
 	}
@@ -430,6 +432,7 @@ describe("Dynamic adapter that gets mapping from initial config", () => {
 		longFormat = true;
 		parameters = [
 			{ parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
+			{ parameter: "pm10", unit: "ug/m3", key: "particulate_matter_10" },
 			{ parameter: "temperature", unit: "f", key: "tempf" },
 		];
 	}
@@ -464,8 +467,9 @@ describe("Dynamic adapter that gets mapping from delayed configure", () => {
 		// Do some other things for whatever reasone
 		// configure by passing a map
 		cln.configure({
-			parameters: [
+			parameters : [
 				{ parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
+				{ parameter: "pm10", unit: "ug/m3", key: "particulate_matter_10" },
 				{ parameter: "temperature", unit: "f", key: "tempf" },
 			],
 			timeEnding: true,
@@ -502,6 +506,12 @@ describe("Client with measurement errors", () => {
 				datetime: "2024-01-01T00:00:00-08:00",
 				parameter: "particulate_matter_25",
 				value: 10,
+			},
+			{
+				station: "ts1",
+				datetime: "2024-01-01T00:00:00-08:00",
+				parameter: "particulate_matter_10",
+				value: 0,
 			},
 			{
 				station: "ts1",
@@ -561,9 +571,9 @@ describe("Client with measurement errors", () => {
 				locations: 1,
 				bounds: [-123.12121, 45.56665, -123.12121, 45.56665],
 				systems: 1,
-				sensors: 2,
+				sensors: 3,
 				flags: 0,
-				measurements: 7,
+				measurements: 8,
 				datetimeFrom: "2024-01-01T00:00:00-08:00",
 				datetimeTo: "2024-01-02T01:00:00-08:00",
 				errors: {},
@@ -614,6 +624,7 @@ describe("Client with measurement errors", () => {
 		isMobile = () => false;
 		parameters = [
 			{ parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
+			{ parameter: "pm10", unit: "ug/m3", key: "particulate_matter_10" }, 
 			{ parameter: "temperature", unit: "f", key: "tempf" },
 		];
 
@@ -625,7 +636,7 @@ describe("Client with measurement errors", () => {
 	test("parameter check", () => {
 		const cln = new JsonClient();
 		const keys = cln.parameters.map((o) => o.key);
-		expect(keys).toStrictEqual(["particulate_matter_25", "tempf"]);
+		expect(keys).toStrictEqual(["particulate_matter_25","particulate_matter_10", "tempf"]);
 	});
 
 	test("outputs correct format", async () => {
@@ -635,7 +646,7 @@ describe("Client with measurement errors", () => {
 		//console.dir(data.measurements, { depth: null })
 		//console.dir(expected.measurements, { depth: null })
 		//console.dir(expected, { depth: null })
-		expect(data.measurements.length).toBe(7);
+		expect(data.measurements.length).toBe(8);
 		expect(data).toStrictEqual(expected);
 	});
 
@@ -669,12 +680,18 @@ describe("Client with digit group and decimal delimiter setting", () => {
 			},
 			{
 				station: "ts1",
+				datetime: "2024-01-01T00:00:00-08:00",
+				parameter: "particulate_matter_10", 
+				value: "0",
+			},
+			{
+				station: "ts1",
 				datetime: "2024-01-02T01:00:00-08:00",
 				parameter: "particulate_matter_25",
 				value: "45",
 			},
 			{
-				station: "ts1",
+			station: "ts1",
 				datetime: "2024-01-02T01:00:00-08:00",
 				parameter: "tempf",
 				value: "45",
@@ -703,9 +720,9 @@ describe("Client with digit group and decimal delimiter setting", () => {
 				locations: 1,
 				bounds: [-123.12121, 45.56665, -123.12121, 45.56665],
 				systems: 1,
-				sensors: 2,
+				sensors: 3,
 				flags: 0,
-				measurements: 4,
+				measurements: 5,
 				datetimeFrom: "2024-01-01T00:00:00-08:00",
 				datetimeTo: "2024-01-02T01:00:00-08:00",
 			},
@@ -718,10 +735,15 @@ describe("Client with digit group and decimal delimiter setting", () => {
 				value: 65.9,
 			},
 			{
-				"key": "testing/ts1/pm25:mass",
-				"timestamp": "2024-01-02T01:00:00-08:00",
-				"value": 45,
-     		},
+				key: "testing/ts1/pm10:mass",
+				timestamp: "2024-01-01T00:00:00-08:00",
+				value: 0,
+			},
+			{
+				key: "testing/ts1/pm25:mass",
+				timestamp: "2024-01-02T01:00:00-08:00",
+				value: 45,
+     	},
 			{
 				key: "testing/ts1/temperature",
 				timestamp: "2024-01-02T01:00:00-08:00",
@@ -753,6 +775,7 @@ describe("Client with digit group and decimal delimiter setting", () => {
 		numberFormat = {decimal: "comma", digitGroup: "dot"} as const;
 		parameters = [
 			{ parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
+      { parameter: "pm10", unit: "ug/m3", key: "particulate_matter_10" },
 			{ parameter: "temperature", unit: "f", key: "tempf" },
 		];
 
@@ -764,13 +787,13 @@ describe("Client with digit group and decimal delimiter setting", () => {
 	test("parameter check", () => {
 		const cln = new JsonClient();
 		const keys = cln.parameters.map((o) => o.key);
-		expect(keys).toStrictEqual(["particulate_matter_25", "tempf"]);
+		expect(keys).toStrictEqual(["particulate_matter_25", "particulate_matter_10", "tempf"]);
 	});
 
 	test("outputs correct format", async () => {
 		const cln = new JsonClient();
 		const data = await cln.load();
-		expect(data.measurements.length).toBe(4);
+		expect(data.measurements.length).toBe(5);
 		expect(data).toStrictEqual(expected);
 	});
 
@@ -802,6 +825,7 @@ describe("Client with jmespath responsePath nested data key", () => {
         isMobile = () => false;
         parameters = [
             { parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
+            { parameter: "pm10", unit: "ug/m3", key: "particulate_matter_10" },
             { parameter: "temperature", unit: "f", key: "tempf" },
         ];
     }
@@ -832,6 +856,7 @@ describe("Client with jmespath responsePath on single resource", () => {
         isMobile = false;
         parameters = [
             { parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
+            { parameter: "pm10", unit: "ug/m3", key: "particulate_matter_10" },
             { parameter: "temperature", unit: "f", key: "tempf" },
         ];
     }
@@ -863,6 +888,7 @@ describe("Client with string responsePath on single resource", () => {
         isMobile = () => false;
         parameters = [
             { parameter: "pm25", unit: "ug/m3", key: "particulate_matter_25" },
+            { parameter: "pm10", unit: "ug/m3", key: "particulate_matter_10" },
             { parameter: "temperature", unit: "f", key: "tempf" },
         ];
     }

--- a/tests/fixtures/sampledata.ts
+++ b/tests/fixtures/sampledata.ts
@@ -20,15 +20,15 @@ export const widedata = {
 		{
 			station: "ts1",
 			datetime: "2024-01-01T01:00:00-08:00",
-			particulate_matter_25: null,           // null value should be ignored
-			particulate_matter_10: '',             // zero length string should be ignored
+			particulate_matter_25: null, // null value should be ignored
+			particulate_matter_10: "", // zero length string should be ignored
 			tempf: 80,
 		},
 		{
 			station: "ts1",
 			datetime: "2024-01-01T02:00:00-08:00",
-			particulate_matter_25: undefined,     // undefinded should be ignored
-			particulate_matter_10: ' ',           // blanks should be ignored
+			particulate_matter_25: undefined, // undefinded should be ignored
+			particulate_matter_10: " ", // blanks should be ignored
 		},
 	],
 };
@@ -57,7 +57,7 @@ export const measurementErrors = {
 			datetime: "2024-01-01T05:00:00-08:00",
 			tempf: "22", // number as string
 		},
-  ],
+	],
 };
 
 export const csvdata = {

--- a/tests/fixtures/sampledata.ts
+++ b/tests/fixtures/sampledata.ts
@@ -66,7 +66,7 @@ export const expectedOutput = {
 		sourceName: "testing",
 		ingestMatchingMethod: "ingest-id",
 		startedOn: "2025-06-01T01:00:00-04:00",
-	 	finishedOn: "2025-06-01T01:00:00-04:00",
+		finishedOn: "2025-06-01T01:00:00-04:00",
 		exportedOn: "2025-06-01T01:00:00-04:00",
 		fetchSummary: {
 			sourceName: "testing",

--- a/tests/fixtures/sampledata.ts
+++ b/tests/fixtures/sampledata.ts
@@ -20,7 +20,15 @@ export const widedata = {
 		{
 			station: "ts1",
 			datetime: "2024-01-01T01:00:00-08:00",
+			particulate_matter_25: null,           // null value should be ignored
+			particulate_matter_10: '',             // zero length string should be ignored
 			tempf: 80,
+		},
+		{
+			station: "ts1",
+			datetime: "2024-01-01T02:00:00-08:00",
+			particulate_matter_25: undefined,     // undefinded should be ignored
+			particulate_matter_10: ' ',           // blanks should be ignored
 		},
 	],
 };
@@ -49,7 +57,7 @@ export const measurementErrors = {
 			datetime: "2024-01-01T05:00:00-08:00",
 			tempf: "22", // number as string
 		},
-	],
+  ],
 };
 
 export const csvdata = {

--- a/tests/fixtures/sampledata.ts
+++ b/tests/fixtures/sampledata.ts
@@ -1,5 +1,4 @@
 const tempf = 26.7;
-
 export const widedata = {
 	locations: [
 		{
@@ -15,6 +14,7 @@ export const widedata = {
 			station: "ts1",
 			datetime: "2024-01-01T00:00:00-08:00",
 			particulate_matter_25: 10,
+			particulate_matter_10: 0,
 			tempf: 80,
 		},
 		{
@@ -56,8 +56,8 @@ export const csvdata = {
 	locations:
 		'station,site_name,latitude,longitude,averaging\n"ts1","test site #1",45.56665, -123.12121, 3600',
 	measurements:
-		'station,datetime,particulate_matter_25,tempf\n"ts1","2024-01-01T00:00:00-08:00",10,80\n"ts1","2024-01-01T01:00:00-08:00",,80',
-	all: 'station,site_name,latitude,longitude,averaging,datetime,particulate_matter_25,tempf\n"ts1","test site #1",45.56665,-123.12121,3600,"2024-01-01T00:00:00-08:00",10,80\n"ts1","test site #1",45.56665,-123.12121,3600,"2024-01-01T01:00:00-08:00",,80',
+		'station,datetime,particulate_matter_25,particulate_matter_10,tempf\n"ts1","2024-01-01T00:00:00-08:00",10,0,80\n"ts1","2024-01-01T01:00:00-08:00",,,80',
+	all: 'station,site_name,latitude,longitude,averaging,datetime,particulate_matter_25,particulate_matter_10,tempf\n"ts1","test site #1",45.56665,-123.12121,3600,"2024-01-01T00:00:00-08:00",10,0,80\n"ts1","test site #1",45.56665,-123.12121,3600,"2024-01-01T01:00:00-08:00",,,80',
 };
 
 export const expectedOutput = {
@@ -66,16 +66,16 @@ export const expectedOutput = {
 		sourceName: "testing",
 		ingestMatchingMethod: "ingest-id",
 		startedOn: "2025-06-01T01:00:00-04:00",
-		finishedOn: "2025-06-01T01:00:00-04:00",
+	 	finishedOn: "2025-06-01T01:00:00-04:00",
 		exportedOn: "2025-06-01T01:00:00-04:00",
 		fetchSummary: {
 			sourceName: "testing",
 			locations: 1,
 			bounds: [-123.12121, 45.56665, -123.12121, 45.56665],
 			systems: 1,
-			sensors: 2,
+			sensors: 3,
 			flags: 0,
-			measurements: 3,
+			measurements: 4,
 			errors: {},
 			datetimeFrom: "2024-01-01T00:00:00-08:00",
 			datetimeTo: "2024-01-01T01:00:00-08:00",
@@ -108,6 +108,15 @@ export const expectedOutput = {
 							flags: [],
 						},
 						{
+							key: "testing/ts1/pm10:mass",
+							status: "asdf",
+							parameter: "pm10:mass",
+							units: "ug/m3",
+							averaging_interval_secs: 3600,
+							logging_interval_secs: 3600,
+							flags: [],
+						},
+						{
 							key: "testing/ts1/temperature",
 							status: "asdf",
 							parameter: "temperature",
@@ -126,6 +135,11 @@ export const expectedOutput = {
 			key: "testing/ts1/pm25:mass",
 			timestamp: "2024-01-01T00:00:00-08:00",
 			value: 10,
+		},
+		{
+			key: "testing/ts1/pm10:mass",
+			timestamp: "2024-01-01T00:00:00-08:00",
+			value: 0,
 		},
 		{
 			key: "testing/ts1/temperature",

--- a/tests/fixtures/wideformat.json
+++ b/tests/fixtures/wideformat.json
@@ -13,6 +13,7 @@
 			"station": "ts1",
 			"datetime": "2024-01-01T00:00:00-08:00",
 			"particulate_matter_25": 10,
+			"particulate_matter_10": 0,
 			"tempf": 80
 		}
 	]


### PR DESCRIPTION
In the current implementation when transforming wide data there is a bug in the value check when evauluating truthiness wherein a value of `0` evaluates `false` meaning it is excluded. 

```ts
if (value !== undefined && (value || this.longFormat)) {
```

This PR reworks this check and updates test to ensure value of `0` in wide format properly passes through.
