### PR TITLE
datetime formatting refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,27 +337,54 @@ timestamp lives in the source row, same as any other field mapping:
 datetime = 'observed_at'
 ```
 
-#### Parsing the datetimes
+#### Parsing datetimes
 
 `datetimeType` tells transform how to interpret the value derived from `datetime`:
 
-| datetimeType | Description |
+| `datetimeType` | Description |
 |---|---|
 |"string" (default) |	A formatted date/time string, parsed using `datetimeFormat` and `timezone`.|
 |"seconds" | 	A Unix epoch value in seconds (number or numeric string).|
 | "milliseconds" |	A Unix epoch value in milliseconds (number or numeric string).|
 
-For string timestamps, set `datetimeFormat` to a [Luxon format string](https://github.com/moment/luxon/blob/master/docs/formatting.md#table-of-tokens)
-matching the source data formatting. Include`timezone` if the string does not already encode an offset:
+
+For string timestamps, `datetimeFormat` defaults to `ISO_UTC`, which handles ISO-8601,
+2026-06-30T22:00:00Z, with or without milliseconds, and with either a Z designator or
+a numeric offset.
+
+For other shapes, set `datetimeFormat` to a [Luxon format string](https://github.com/moment/luxon/blob/master/docs/formatting.md#table-of-tokens).
+
+Transform includes some named constants which provide common formats in a
+ convenient variable: 
+
+| Constant |	Matches |
+|---|---|
+| `ISO_UTC`  (default) | 	`2026-06-30T22:00:00Z`, 2026-06-30T22:00:00+00:00 | 
+| `SQL_UTC`	| `2026-06-30 22:00:00Z` space separator, Zulu designator |
+| `SQL_NAIVE` |	2026-06-30 22:00:00 — no zone info; requires timezone |
+
+
+```ts
+import { SQL_UTC } from '@openaq/transform/core';
+
+datetime = 'date_added';
+datetimeFormat = SQL_UTC;
+```
+
+> [!IMPORTANT]
+> Set` timezone` only when the source string carries no time zone information.
+> If the value already ends in `'Z'` or an offset (e.g. `'-05:00'`), supplying timezone throws
+>  a `TypeError`.
+
 
 ```ts
 datetime = 'observed_at';
 datetimeType = 'string'; // default, can be omitted
-datetimeFormat = "yyyy-MM-dd'T'HH:mm:ssZZ"; // default
-timezone = 'America/Los_Angeles'; // only needed if the string has no offset
+datetimeFormat = "ISO_NAIVE";
+timezone = 'America/Los_Angeles'; 
 ```
 
-For Unix timestamps, set `datetimeType` and omit `datetimeFormat`:
+For Unix timestamps, set `datetimeType`to `seconds` or `milliseconds` and omit `datetimeFormat`:
 
 ```ts
 datetime = 'observed_at';
@@ -489,7 +516,7 @@ column
 
 ```ts
 import { NodeClient } from 'openaq-transform/node';
-import { Resource } from 'openaq-transform/core';
+import { Resource, constant } from 'openaq-transform/core';
 
 
 export class Client extends NodeClient {
@@ -500,17 +527,16 @@ export class Client extends NodeClient {
   };
   parser = 'json';
   reader = 'api';
-  averagingIntervalKey = 3600;
-  isMobileKey = false;
+  averagingInterval = constant(3600);
+  isMobile = false;
   longFormat = true
-  locationIdKey = 'locationId'
-  datetimeKey = 'datetime'
-  locationLabelKey = 'name'
-  xGeometryKey = 'lon'
-  yGeometryKey = 'lat'
-  parameterNameKey = 'parameter'
-  parameterValueKey = 'value'
-  datetimeFormat = null
+  locationId = 'locationId'
+  datetime = 'datetime'
+  locationLabel = 'name'
+  xGeometry = 'lon'
+  yGeometry = 'lat'
+  parameterName = 'parameter'
+  parameterValue = 'value'
   parameters = [
     { parameter: 'pm25', unit: 'ug/m3', key: 'pm25' },
   ]
@@ -519,7 +545,8 @@ export class Client extends NodeClient {
 ```
 ## TransformData Output
 
-`TransformData` is the main output of the transform client, returned by `client.load()`. It contains everything the ingestor needs to process a batch of air quality data.
+`TransformData` is the main output of the transform client, returned by `client.load()`.
+It contains everything the ingestor needs to process a batch of air quality data.
 
 ### Structure
 

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -82,7 +82,7 @@ export abstract class Client<
 	geometryProjection: string | PathExpression | ConstantValue | ParseFunction =
 		"projection";
 	datetimeType: DatetimeType = "string";
-	datetimeFormat: string = "yyyy-MM-dd'T'HH:mm:ssZZ";
+	datetimeFormat?: string;
 	timeEnding: boolean = true;
 
 	// mapped data variables
@@ -184,8 +184,9 @@ export abstract class Client<
 		if (this._params?.datetimeFormat) {
 			this.datetimeFormat = this._params.datetimeFormat;
 		}
-		if (this.datetimeType !== "string" && this._params?.datetimeFormat) {
+		if (this.datetimeType !== "string" && this.datetimeFormat) {
 			throw new ConfigError(
+
 				`datetimeFormat is not used when datetimeType is "${this.datetimeType}"`,
 			);
 		}
@@ -380,9 +381,9 @@ export abstract class Client<
 		try {
 			const body = refreshToken
 				? JSON.stringify({
-						grant_type: "refresh_token",
-						refresh_token: refreshToken,
-					})
+					grant_type: "refresh_token",
+					refresh_token: refreshToken,
+				})
 				: undefined;
 
 			const res = await fetch(url, {
@@ -496,15 +497,20 @@ export abstract class Client<
 			);
 		}
 
+		const zone =
+			typeof dtValue === "string" && /([Zz]|[+-]\d{2}:?\d{2})$/.test(dtValue);
+
 		let dt =
-			this.datetimeType === "string"
-				? new Datetime(dtValue as string, {
-						format: this.datetimeFormat,
-						timezone: this.timezone,
-					})
+			this.datetimeType === "string" ?
+				new Datetime(dtValue as string, {
+
+					format: this.datetimeFormat,
+					...(zone ? { locationTimezone: this.timezone }
+						: { timezone: this.timezone }),
+				})
 				: new Datetime(toUnixSeconds(dtValue, this.datetimeType), {
-						locationTimezone: this.timezone,
-					});
+					locationTimezone: this.timezone,
+				});
 
 		if (!this.timeEnding) {
 			if (!averagingIntervalSeconds) {
@@ -629,13 +635,13 @@ export abstract class Client<
 
 		return this.normalizeDataStructure(
 			d as
-				| Partial<
-						Record<
-							"measurements" | "locations" | "meta" | "flags" | "sensors",
-							SourceRecord[]
-						>
-				  >
-				| SourceRecord[],
+			| Partial<
+				Record<
+					"measurements" | "locations" | "meta" | "flags" | "sensors",
+					SourceRecord[]
+				>
+			>
+			| SourceRecord[],
 		);
 	}
 
@@ -866,9 +872,9 @@ export abstract class Client<
 		const params: Array<
 			string | PathExpression | ConstantValue | ParseFunction
 		> = this.longFormat
-			? // for long format we will just pass the parameter name key and use that each time
+				? // for long format we will just pass the parameter name key and use that each time
 				[this.parameterName]
-			: this.measurements.parameterKeys();
+				: this.measurements.parameterKeys();
 
 		measurements.forEach((measurementRow: SourceRecord) => {
 			try {
@@ -1030,8 +1036,7 @@ export abstract class Client<
 		}
 
 		throw new Error(
-			`Invalid parser method: ${JSON.stringify(method)}${
-				key ? ` with key "${key}"` : ""
+			`Invalid parser method: ${JSON.stringify(method)}${key ? ` with key "${key}"` : ""
 			}`,
 		);
 	}
@@ -1085,8 +1090,7 @@ export abstract class Client<
 		}
 
 		throw new Error(
-			`Invalid reader method: ${JSON.stringify(method)}${
-				key ? ` with key "${key}"` : ""
+			`Invalid reader method: ${JSON.stringify(method)}${key ? ` with key "${key}"` : ""
 			}`,
 		);
 	}
@@ -1166,7 +1170,7 @@ export abstract class Client<
 			provider: this.provider,
 			datetime: translateKey(this.datetime),
 			timezone: this.timezone,
-			datetimeFormat: this.datetimeFormat,
+			datetimeFormat: this.datetimeFormat ?? "ISO-8601",
 			geometryProjection: translateKey(this.geometryProjection),
 			yGeometry: translateKey(this.yGeometry),
 			xGeometry: translateKey(this.xGeometry),

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -186,7 +186,6 @@ export abstract class Client<
 		}
 		if (this.datetimeType !== "string" && this.datetimeFormat) {
 			throw new ConfigError(
-
 				`datetimeFormat is not used when datetimeType is "${this.datetimeType}"`,
 			);
 		}
@@ -381,9 +380,9 @@ export abstract class Client<
 		try {
 			const body = refreshToken
 				? JSON.stringify({
-					grant_type: "refresh_token",
-					refresh_token: refreshToken,
-				})
+						grant_type: "refresh_token",
+						refresh_token: refreshToken,
+					})
 				: undefined;
 
 			const res = await fetch(url, {
@@ -501,16 +500,16 @@ export abstract class Client<
 			typeof dtValue === "string" && /([Zz]|[+-]\d{2}:?\d{2})$/.test(dtValue);
 
 		let dt =
-			this.datetimeType === "string" ?
-				new Datetime(dtValue as string, {
-
-					format: this.datetimeFormat,
-					...(zone ? { locationTimezone: this.timezone }
-						: { timezone: this.timezone }),
-				})
+			this.datetimeType === "string"
+				? new Datetime(dtValue as string, {
+						format: this.datetimeFormat,
+						...(zone
+							? { locationTimezone: this.timezone }
+							: { timezone: this.timezone }),
+					})
 				: new Datetime(toUnixSeconds(dtValue, this.datetimeType), {
-					locationTimezone: this.timezone,
-				});
+						locationTimezone: this.timezone,
+					});
 
 		if (!this.timeEnding) {
 			if (!averagingIntervalSeconds) {
@@ -635,13 +634,13 @@ export abstract class Client<
 
 		return this.normalizeDataStructure(
 			d as
-			| Partial<
-				Record<
-					"measurements" | "locations" | "meta" | "flags" | "sensors",
-					SourceRecord[]
-				>
-			>
-			| SourceRecord[],
+				| Partial<
+						Record<
+							"measurements" | "locations" | "meta" | "flags" | "sensors",
+							SourceRecord[]
+						>
+				  >
+				| SourceRecord[],
 		);
 	}
 
@@ -872,9 +871,9 @@ export abstract class Client<
 		const params: Array<
 			string | PathExpression | ConstantValue | ParseFunction
 		> = this.longFormat
-				? // for long format we will just pass the parameter name key and use that each time
+			? // for long format we will just pass the parameter name key and use that each time
 				[this.parameterName]
-				: this.measurements.parameterKeys();
+			: this.measurements.parameterKeys();
 
 		measurements.forEach((measurementRow: SourceRecord) => {
 			try {
@@ -1036,7 +1035,8 @@ export abstract class Client<
 		}
 
 		throw new Error(
-			`Invalid parser method: ${JSON.stringify(method)}${key ? ` with key "${key}"` : ""
+			`Invalid parser method: ${JSON.stringify(method)}${
+				key ? ` with key "${key}"` : ""
 			}`,
 		);
 	}
@@ -1090,7 +1090,8 @@ export abstract class Client<
 		}
 
 		throw new Error(
-			`Invalid reader method: ${JSON.stringify(method)}${key ? ` with key "${key}"` : ""
+			`Invalid reader method: ${JSON.stringify(method)}${
+				key ? ` with key "${key}"` : ""
 			}`,
 		);
 	}

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,0 +1,23 @@
+/**
+ * ISO-8601, with or without a `Z` / numeric offset, with or without
+ * milliseconds. default when `datetimeFormat` is unset.
+*/
+export const ISO_UTC = 'ISO_UTC';
+
+/** `2026-03-23 00:00:00Z` space separator, Zulu designator. */
+export const SQL_UTC = "SQL_UTC";
+
+/** `2026-03-23 00:00:00` space separater, no zone information, requires `timezone`. */
+export const SQL_NAIVE = "SQL_NAIVE";
+
+
+/**
+ * A datetime format: either one of the named constants, or a raw
+ * Luxon token string for sources that aren't covered by constants.
+ * @see https://moment.github.io/luxon/#/parsing
+ */
+export type DatetimeFormat =
+  | typeof ISO_UTC
+  | typeof SQL_UTC
+  | typeof SQL_NAIVE
+  | (string & {});

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -1,8 +1,8 @@
 /**
  * ISO-8601, with or without a `Z` / numeric offset, with or without
  * milliseconds. default when `datetimeFormat` is unset.
-*/
-export const ISO_UTC = 'ISO_UTC';
+ */
+export const ISO_UTC = "ISO_UTC";
 
 /** `2026-03-23 00:00:00Z` space separator, Zulu designator. */
 export const SQL_UTC = "SQL_UTC";
@@ -10,14 +10,13 @@ export const SQL_UTC = "SQL_UTC";
 /** `2026-03-23 00:00:00` space separater, no zone information, requires `timezone`. */
 export const SQL_NAIVE = "SQL_NAIVE";
 
-
 /**
  * A datetime format: either one of the named constants, or a raw
  * Luxon token string for sources that aren't covered by constants.
  * @see https://moment.github.io/luxon/#/parsing
  */
 export type DatetimeFormat =
-  | typeof ISO_UTC
-  | typeof SQL_UTC
-  | typeof SQL_NAIVE
-  | (string & {});
+	| typeof ISO_UTC
+	| typeof SQL_UTC
+	| typeof SQL_NAIVE
+	| (string & {});

--- a/src/core/datetime.spec.ts
+++ b/src/core/datetime.spec.ts
@@ -1,6 +1,7 @@
 import { DateTime, Duration, Settings } from "luxon";
 import { expect, test } from "vitest";
 import { Datetime } from "./datetime";
+import { ISO_UTC, SQL_NAIVE, SQL_UTC } from "./constants";
 
 const expectedNow = DateTime.local(2025, 6, 1, 1, 0, 0);
 Settings.now = () => expectedNow.toMillis();
@@ -119,6 +120,12 @@ test("datetime string with Z correctly throws when timezone is also included", (
 				locationTimezone: "America/Denver",
 			}),
 	).toThrow(TypeError);
+});
+test("ZZ format parses a bare Z designator as UTC", () => {
+	const dt = new Datetime("2025-01-01T00:00:00Z", {
+		format: "yyyy-MM-dd'T'HH:mm:ssZZ",
+	});
+	expect(dt.toUTC()).toBe("2025-01-01T00:00:00Z");
 });
 
 test("Datetime string with Z correctly parses and adds timezone offset when format is provided", () => {
@@ -367,4 +374,33 @@ test("now with offset and timezone combined", () => {
 test("now without timezone falls back to system/local zone (backwards compatible)", () => {
 	const now = Datetime.now();
 	expect(now.toUTC()).toBe("2025-06-01T05:00:00Z");
+});
+
+
+test("ISO_UTC alias parses a Z-suffixed string as UTC", () => {
+	const dt = new Datetime("2025-06-01T00:00:00Z", { format: ISO_UTC });
+	expect(dt.toUTC()).toBe("2025-06-01T00:00:00Z");
+});
+
+test("ISO_UTC is equivalent default", () => {
+	const a = new Datetime("2025-06-01T00:00:00Z", { format: ISO_UTC });
+	const b = new Datetime("2025-06-01T00:00:00Z");
+	expect(a.toUTC()).toBe(b.toUTC());
+});
+
+test("SQL_UTC parses correctly", () => {
+	const dt = new Datetime("2025-06-01 00:00:00Z", { format: SQL_UTC });
+	expect(dt.toUTC()).toBe("2025-06-01T00:00:00Z");
+});
+
+test("SQL_NAIVE requires a timezone", () => {
+	const dt = new Datetime("2025-05-01 00:00:00", {
+		format: SQL_NAIVE, timezone: "America/Denver",
+	});
+	expect(dt.toUTC()).toBe("2025-05-01T06:00:00Z");
+});
+
+test("custom format strings pass through as Luxon format", () => {
+	const dt = new Datetime("01/06/2025 00:00", { format: "dd/MM/yyyy HH:mm", timezone: "UTC" });
+	expect(dt.toUTC()).toBe("2025-06-01T00:00:00Z");
 });

--- a/src/core/datetime.spec.ts
+++ b/src/core/datetime.spec.ts
@@ -394,9 +394,12 @@ test("SQL_UTC parses correctly", () => {
 
 // should this throw an error or work?
 test("SQL_UTC rejects timestamps with hours", () => {
-	expect(() => new Datetime("2025-06-01 00:00:00+05:00", {
-    format: SQL_UTC
-  })).toThrow(Error);
+	expect(
+		() =>
+			new Datetime("2025-06-01 00:00:00+05:00", {
+				format: SQL_UTC,
+			}),
+	).toThrow(Error);
 });
 
 test("SQL_NAIVE uses a timezone", () => {
@@ -409,18 +412,24 @@ test("SQL_NAIVE uses a timezone", () => {
 
 // right now this would fall back to using luxons default
 test("SQL_NAIVE requires a timezone", () => {
-  expect(() => new Datetime("2025-05-01 00:00:00", {
-		format: SQL_NAIVE,
-    timezone: undefined,
-	})).toThrow(Error);
+	expect(
+		() =>
+			new Datetime("2025-05-01 00:00:00", {
+				format: SQL_NAIVE,
+				timezone: undefined,
+			}),
+	).toThrow(Error);
 });
 
 // this currently works
 test("unknown format format code throws error", () => {
-	expect(() => new Datetime("01/06/2025 00:00", {
-		format: "UNKNOWN_FORMAT_CODE",
-		timezone: "UTC",
-	})).toThrow(Error);
+	expect(
+		() =>
+			new Datetime("01/06/2025 00:00", {
+				format: "UNKNOWN_FORMAT_CODE",
+				timezone: "UTC",
+			}),
+	).toThrow(Error);
 });
 
 test("custom format strings pass through as Luxon format", () => {

--- a/src/core/datetime.spec.ts
+++ b/src/core/datetime.spec.ts
@@ -392,12 +392,35 @@ test("SQL_UTC parses correctly", () => {
 	expect(dt.toUTC()).toBe("2025-06-01T00:00:00Z");
 });
 
-test("SQL_NAIVE requires a timezone", () => {
+// should this throw an error or work?
+test("SQL_UTC rejects timestamps with hours", () => {
+	expect(() => new Datetime("2025-06-01 00:00:00+05:00", {
+    format: SQL_UTC
+  })).toThrow(Error);
+});
+
+test("SQL_NAIVE uses a timezone", () => {
 	const dt = new Datetime("2025-05-01 00:00:00", {
 		format: SQL_NAIVE,
 		timezone: "America/Denver",
 	});
 	expect(dt.toUTC()).toBe("2025-05-01T06:00:00Z");
+});
+
+// right now this would fall back to using luxons default
+test("SQL_NAIVE requires a timezone", () => {
+  expect(() => new Datetime("2025-05-01 00:00:00", {
+		format: SQL_NAIVE,
+    timezone: undefined,
+	})).toThrow(Error);
+});
+
+// this currently works
+test("unknown format format code throws error", () => {
+	expect(() => new Datetime("01/06/2025 00:00", {
+		format: "UNKNOWN_FORMAT_CODE",
+		timezone: "UTC",
+	})).toThrow(Error);
 });
 
 test("custom format strings pass through as Luxon format", () => {

--- a/src/core/datetime.spec.ts
+++ b/src/core/datetime.spec.ts
@@ -1,7 +1,7 @@
 import { DateTime, Duration, Settings } from "luxon";
 import { expect, test } from "vitest";
-import { Datetime } from "./datetime";
 import { ISO_UTC, SQL_NAIVE, SQL_UTC } from "./constants";
+import { Datetime } from "./datetime";
 
 const expectedNow = DateTime.local(2025, 6, 1, 1, 0, 0);
 Settings.now = () => expectedNow.toMillis();
@@ -376,7 +376,6 @@ test("now without timezone falls back to system/local zone (backwards compatible
 	expect(now.toUTC()).toBe("2025-06-01T05:00:00Z");
 });
 
-
 test("ISO_UTC alias parses a Z-suffixed string as UTC", () => {
 	const dt = new Datetime("2025-06-01T00:00:00Z", { format: ISO_UTC });
 	expect(dt.toUTC()).toBe("2025-06-01T00:00:00Z");
@@ -395,12 +394,16 @@ test("SQL_UTC parses correctly", () => {
 
 test("SQL_NAIVE requires a timezone", () => {
 	const dt = new Datetime("2025-05-01 00:00:00", {
-		format: SQL_NAIVE, timezone: "America/Denver",
+		format: SQL_NAIVE,
+		timezone: "America/Denver",
 	});
 	expect(dt.toUTC()).toBe("2025-05-01T06:00:00Z");
 });
 
 test("custom format strings pass through as Luxon format", () => {
-	const dt = new Datetime("01/06/2025 00:00", { format: "dd/MM/yyyy HH:mm", timezone: "UTC" });
+	const dt = new Datetime("01/06/2025 00:00", {
+		format: "dd/MM/yyyy HH:mm",
+		timezone: "UTC",
+	});
 	expect(dt.toUTC()).toBe("2025-06-01T00:00:00Z");
 });

--- a/src/core/datetime.ts
+++ b/src/core/datetime.ts
@@ -1,6 +1,7 @@
 import { DateTime, Duration } from "luxon";
 import type { DatetimeOptions, TimeOffset } from "./types/datetime";
 import { formatValueForLog } from "./utils";
+import { ISO_UTC, SQL_UTC, SQL_NAIVE, DatetimeFormat } from './constants';
 
 function assertValid(
 	dt: DateTime,
@@ -13,6 +14,26 @@ function assertValid(
 function isValidDatetime(dt: DateTime): dt is DateTime<true> {
 	return dt.isValid;
 }
+
+
+export const ISO_FORMAT = Symbol("iso");
+
+
+const FORMATS: Record<string, string | typeof ISO_FORMAT> = {
+	[ISO_UTC]: ISO_FORMAT,
+	[SQL_UTC]: "yyyy-MM-dd HH:mm:ssZZ",
+	[SQL_NAIVE]: "yyyy-MM-dd HH:mm:ss",
+};
+
+
+/** @internal */
+export function resolveFormat(f?: DatetimeFormat) {
+	if (!f) {
+		return ISO_FORMAT;
+	}
+	return FORMATS[f] ?? f;
+}
+
 /**
  * A wrapper class for Luxon's `DateTime` that provides simplified
  * handling for various date and time inputs, with a focus on timezone management.
@@ -71,14 +92,20 @@ export class Datetime {
 		input: string | number | Date | DateTime,
 		options?: DatetimeOptions,
 	) {
-		if (
-			(options?.format?.includes("Z") ||
-				(typeof input === "string" && input.includes("Z"))) &&
-			options?.timezone
-		)
+
+		const resolvedFormat = resolveFormat(options?.format);
+		const formatHasZone =
+			typeof resolvedFormat === "string" && /Z/.test(resolvedFormat);
+		const inputHasZone = typeof input === "string" && /Z$/i.test(input);
+
+		if ((formatHasZone || inputHasZone) && options?.timezone) {
 			throw new TypeError(
-				`You cannot include both the Z option in your format (${options.format}) and a timezone (${options.timezone})`,
+				`Cannot set a timezone ("${options.timezone}") when the input or format ` +
+				`also has zone information.`,
 			);
+		}
+
+
 		if (input instanceof Date && !options?.timezone) {
 			throw new TypeError("Input of type Date must include timezone option");
 		}
@@ -108,6 +135,7 @@ export class Datetime {
 			throw new TypeError("Input required");
 		}
 		let parsedDate: DateTime;
+		const resolvedFormat = resolveFormat(this.format);
 
 		if (this.#input instanceof DateTime) {
 			parsedDate = this.#input;
@@ -119,33 +147,34 @@ export class Datetime {
 				setZone: true,
 			});
 		} else {
-			if (!this.format) {
-				// defaults to ISO-8601
-				// the setZone option will ensure that it sets the zone to the string offset and not the local zone
+			if (resolvedFormat === ISO_FORMAT) {
 				parsedDate = DateTime.fromISO(this.#input, { setZone: true });
 			} else {
-				if (this.timezone) {
-					parsedDate = DateTime.fromFormat(this.#input, this.format, {
-						zone: this.timezone,
-					});
-				} else {
-					parsedDate = DateTime.fromFormat(this.#input, this.format, {
-						setZone: true,
-					});
+				let input = this.#input;
+				if (/ZZ/.test(resolvedFormat)) {
+					input = input.replace(/Z$/i, "+00:00");
 				}
+
+				parsedDate = this.timezone
+					? DateTime.fromFormat(input, resolvedFormat, { zone: this.timezone })
+					: DateTime.fromFormat(input, resolvedFormat, { setZone: true });
 			}
 
 			if (!this.locationTimezone && parsedDate.zoneName) {
 				this.locationTimezone = parsedDate.zoneName;
 			}
 		}
+
 		assertValid(
 			parsedDate,
 			() =>
-				`Invalid date input: "${formatValueForLog(this.#input)}" with format "${this.format}: ${parsedDate.invalidReason}".`,
+				`Invalid date input: "${formatValueForLog(this.#input)}" with format ` +
+				`"${resolvedFormat === ISO_FORMAT ? "ISO-8601" : resolvedFormat}". ` +
+				`${parsedDate.invalidReason}: ${parsedDate.invalidExplanation ?? ""}`,
 		);
 		return parsedDate;
 	}
+
 
 	/**
 	 * Converts the internal Luxon `DateTime` to a native JavaScript `Date` object.

--- a/src/core/datetime.ts
+++ b/src/core/datetime.ts
@@ -1,7 +1,7 @@
 import { DateTime, Duration } from "luxon";
+import { type DatetimeFormat, ISO_UTC, SQL_NAIVE, SQL_UTC } from "./constants";
 import type { DatetimeOptions, TimeOffset } from "./types/datetime";
 import { formatValueForLog } from "./utils";
-import { ISO_UTC, SQL_UTC, SQL_NAIVE, DatetimeFormat } from './constants';
 
 function assertValid(
 	dt: DateTime,
@@ -15,16 +15,13 @@ function isValidDatetime(dt: DateTime): dt is DateTime<true> {
 	return dt.isValid;
 }
 
-
 export const ISO_FORMAT = Symbol("iso");
-
 
 const FORMATS: Record<string, string | typeof ISO_FORMAT> = {
 	[ISO_UTC]: ISO_FORMAT,
 	[SQL_UTC]: "yyyy-MM-dd HH:mm:ssZZ",
 	[SQL_NAIVE]: "yyyy-MM-dd HH:mm:ss",
 };
-
 
 /** @internal */
 export function resolveFormat(f?: DatetimeFormat) {
@@ -92,7 +89,6 @@ export class Datetime {
 		input: string | number | Date | DateTime,
 		options?: DatetimeOptions,
 	) {
-
 		const resolvedFormat = resolveFormat(options?.format);
 		const formatHasZone =
 			typeof resolvedFormat === "string" && /Z/.test(resolvedFormat);
@@ -101,10 +97,9 @@ export class Datetime {
 		if ((formatHasZone || inputHasZone) && options?.timezone) {
 			throw new TypeError(
 				`Cannot set a timezone ("${options.timezone}") when the input or format ` +
-				`also has zone information.`,
+					`also has zone information.`,
 			);
 		}
-
 
 		if (input instanceof Date && !options?.timezone) {
 			throw new TypeError("Input of type Date must include timezone option");
@@ -174,7 +169,6 @@ export class Datetime {
 		);
 		return parsedDate;
 	}
-
 
 	/**
 	 * Converts the internal Luxon `DateTime` to a native JavaScript `Date` object.

--- a/src/core/datetime.ts
+++ b/src/core/datetime.ts
@@ -1,8 +1,8 @@
 import { DateTime, Duration } from "luxon";
 import { type DatetimeFormat, ISO_UTC, SQL_NAIVE, SQL_UTC } from "./constants";
+import { ConfigError } from "./errors";
 import type { DatetimeOptions, TimeOffset } from "./types/datetime";
 import { formatValueForLog } from "./utils";
-import { ConfigError } from "./errors";
 
 function assertValid(
 	dt: DateTime,
@@ -98,20 +98,19 @@ export class Datetime {
 		if ((formatHasZone || inputHasZone) && options?.timezone) {
 			throw new TypeError(
 				`Cannot set a timezone ("${options.timezone}") when the input or format ` +
-				`also has zone information.`,
+					`also has zone information.`,
 			);
 		}
 		if (options?.format === SQL_NAIVE && !options?.timezone) {
 			throw new ConfigError(
 				`Format "${SQL_NAIVE}" carries no zone information and requires a ` +
-				`"timezone" option to be interpreted.`,
+					`"timezone" option to be interpreted.`,
 			);
 		}
 
 		if (input instanceof Date && !options?.timezone) {
 			throw new TypeError("Input of type Date must include timezone option");
 		}
-
 
 		this.#input = input;
 		this.format = options?.format;
@@ -122,10 +121,9 @@ export class Datetime {
 		if (options?.format === SQL_UTC && this.date.offset !== 0) {
 			throw new ConfigError(
 				`Format "${SQL_UTC}" requires a UTC offset, but got ` +
-				`"${this.date.toFormat("ZZ")}" from "${formatValueForLog(input)}".`,
+					`"${this.date.toFormat("ZZ")}" from "${formatValueForLog(input)}".`,
 			);
 		}
-
 
 		if (this.date > DateTime.now()) {
 			throw new RangeError(

--- a/src/core/datetime.ts
+++ b/src/core/datetime.ts
@@ -2,6 +2,7 @@ import { DateTime, Duration } from "luxon";
 import { type DatetimeFormat, ISO_UTC, SQL_NAIVE, SQL_UTC } from "./constants";
 import type { DatetimeOptions, TimeOffset } from "./types/datetime";
 import { formatValueForLog } from "./utils";
+import { ConfigError } from "./errors";
 
 function assertValid(
 	dt: DateTime,
@@ -97,23 +98,40 @@ export class Datetime {
 		if ((formatHasZone || inputHasZone) && options?.timezone) {
 			throw new TypeError(
 				`Cannot set a timezone ("${options.timezone}") when the input or format ` +
-					`also has zone information.`,
+				`also has zone information.`,
+			);
+		}
+		if (options?.format === SQL_NAIVE && !options?.timezone) {
+			throw new ConfigError(
+				`Format "${SQL_NAIVE}" carries no zone information and requires a ` +
+				`"timezone" option to be interpreted.`,
 			);
 		}
 
 		if (input instanceof Date && !options?.timezone) {
 			throw new TypeError("Input of type Date must include timezone option");
 		}
+
+
 		this.#input = input;
 		this.format = options?.format;
 		this.timezone = options?.timezone;
 		this.locationTimezone = options?.locationTimezone ?? options?.timezone;
 		this.date = this.parseDate();
+
+		if (options?.format === SQL_UTC && this.date.offset !== 0) {
+			throw new ConfigError(
+				`Format "${SQL_UTC}" requires a UTC offset, but got ` +
+				`"${this.date.toFormat("ZZ")}" from "${formatValueForLog(input)}".`,
+			);
+		}
+
+
 		if (this.date > DateTime.now()) {
 			throw new RangeError(
 				`Date string cannot be in the future. ${String(
 					input,
-				)} --> ${this.toLocal()}`,
+				)} ${this.toLocal()}`,
 			);
 		}
 	}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,4 +1,6 @@
 export { Client } from "./client";
+export type { DatetimeFormat } from "./constants";
+export { ISO_UTC, SQL_NAIVE, SQL_UTC } from "./constants";
 export { Datetime } from "./datetime";
 export {
 	ConfigError,
@@ -62,7 +64,3 @@ export {
 	isStructuredKey,
 } from "./types";
 export { constant, jmespath } from "./utils";
-
-
-export { ISO_UTC, SQL_UTC, SQL_NAIVE } from "./constants";
-export type { DatetimeFormat } from "./constants";

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -62,3 +62,7 @@ export {
 	isStructuredKey,
 } from "./types";
 export { constant, jmespath } from "./utils";
+
+
+export { ISO_UTC, SQL_UTC, SQL_NAIVE } from "./constants";
+export type { DatetimeFormat } from "./constants";


### PR DESCRIPTION
Changes the default `datetimeFormat` (`yyyy-MM-dd'T'HH:mm:ssZZ`) which could not parse `2026-06 30T22:00:00Z`. Adapters with standard ISO sources had to work around the default rather than leverage it, and formats using a `'Z'` parsed successfully but fell back to the system timezone, shifting timestamps.

- `datetimeFormat` now also accepts named constants: `ISO_UTC` (default), `SQL_UTC`,
  `SQL_NAIVE` in addition to  Luxon token strings.
- `ISO_UTC` parses via `fromISO`, handling `Z`, numeric offsets, and optional
  milliseconds. Adapters with ISO sources need no configuration.
- The `timezone` conflict guard resolves aliases before checking for zone tokens,
  and matches the input's trailing designator rather than any `Z` in the string.

Adapters relying on the old default now parse via `fromISO`. Offset suffixed values (`-06:00`) are unaffected. `Z` suffixed values previously threw and now parse.

Setting `timezone` alongside a source string that carries its own zone still throws an error..


for a data field like this:

```json
{
     "date": "2026-06-30T22:00:00.000Z"
}
```

the old configuration would be:

```ts
datetime = "date";
datetimeFormat = undefined as unknown as string;
```
with this change we can omit `datetimeFormat` entirely

```ts 
datetime = "date";
// datetimeFormat = undefined as unknown as string;
```
